### PR TITLE
Fixed leaking I/O handles

### DIFF
--- a/FortnoxAPILibrary/Connectors/AuthorizationConnector.cs
+++ b/FortnoxAPILibrary/Connectors/AuthorizationConnector.cs
@@ -28,12 +28,16 @@ namespace FortnoxAPILibrary.Connectors
 				}
 
 				HttpWebRequest wr = SetupRequest(ConnectionCredentials.FortnoxAPIServer, AuthorizationCode, ClientSecret);
-				WebResponse response = wr.GetResponse();
-				Stream responseStream = response.GetResponseStream();
-				XmlSerializer xs = new XmlSerializer(typeof(Authorization));
-				Authorization auth = (Authorization)xs.Deserialize(responseStream);
-				AccessToken = auth.AccessToken;
-			}
+			    using (WebResponse response = wr.GetResponse())
+			    {
+			        using (Stream responseStream = response.GetResponseStream())
+			        {
+                        XmlSerializer xs = new XmlSerializer(typeof(Authorization));
+                        Authorization auth = (Authorization)xs.Deserialize(responseStream);
+                        AccessToken = auth.AccessToken;
+                    }
+                }
+            }
 			catch (WebException we)
 			{
 				Error = HandleException(we);

--- a/FortnoxAPILibrary/Connectors/SIEConnector.cs
+++ b/FortnoxAPILibrary/Connectors/SIEConnector.cs
@@ -123,25 +123,29 @@ namespace FortnoxAPILibrary.Connectors
 
             try
             {
-                WebResponse response = wr.GetResponse();
-                Stream responseStream = response.GetResponseStream();
-                int b;
+                using (WebResponse response = wr.GetResponse())
+                {
+                    using (Stream responseStream = response.GetResponseStream())
+                    {
+                        int b;
 
-                if (localPath != "")
-                {
-                    using (var writer = new FileStream(localPath, FileMode.Create))
-                    {
-                        while ((b = responseStream.ReadByte()) != -1)
+                        if (localPath != "")
                         {
-                            writer.WriteByte((byte)b);
+                            using (var writer = new FileStream(localPath, FileMode.Create))
+                            {
+                                while ((b = responseStream.ReadByte()) != -1)
+                                {
+                                    writer.WriteByte((byte)b);
+                                }
+                            }
                         }
-                    }
-                }
-                else
-                {
-                    while ((b = responseStream.ReadByte()) != -1)
-                    {
-                        data.Add((byte)b);
+                        else
+                        {
+                            while ((b = responseStream.ReadByte()) != -1)
+                            {
+                                data.Add((byte)b);
+                            }
+                        }
                     }
                 }
             }


### PR DESCRIPTION
Barely any Streams or WebResponse objects were disposed, causing lots
and lots of I/O handle leakage. This had a major impact on long running
applications (i.e. services)