### PR TITLE
Add `paymentpending` filtering option for SupplierInvoices

### DIFF
--- a/FortnoxAPILibrary/Filter.cs
+++ b/FortnoxAPILibrary/Filter.cs
@@ -61,6 +61,9 @@ namespace FortnoxAPILibrary
             /// <remarks/>
             [RealValue("unbooked")]
             Unbooked,
+            /// <remarks/>
+            [RealValue("pendingpayment")]
+            PendingPayment
         }
 
 		/// <remarks/>


### PR DESCRIPTION
Seems like it is forgotten to be implemented.