### PR TITLE
Seems like GetAccessToken is broken. The code can't deserialize the returned JSON from the API.

### DIFF
--- a/FortnoxAPILibrary/Connectors/AuthorizationConnector.cs
+++ b/FortnoxAPILibrary/Connectors/AuthorizationConnector.cs
@@ -1,5 +1,6 @@
 using System.Net;
 using FortnoxAPILibrary.Entities;
+using Authorization = FortnoxAPILibrary.Entities.Authorization;
 
 // ReSharper disable UnusedMember.Global
 
@@ -29,8 +30,8 @@ namespace FortnoxAPILibrary.Connectors
 				var wr = SetupRequest(ConnectionSettings.FortnoxAPIServer, authorizationCode, clientSecret);
                 using var response = wr.GetResponse();
                 using var responseStream = response.GetResponseStream();
-				var authorizationContainer = Deserialize<AuthorizationContainer>(responseStream.ToText());
-				accessToken = authorizationContainer.Authorization.AccessToken;
+				var auth = Deserialize<EntityWrapper<Authorization>>(responseStream.ToText());
+				accessToken = auth.Entity.AccessToken;
 			}
 			catch (WebException we)
 			{

--- a/FortnoxAPILibrary/Connectors/AuthorizationConnector.cs
+++ b/FortnoxAPILibrary/Connectors/AuthorizationConnector.cs
@@ -1,6 +1,5 @@
-using System.IO;
 using System.Net;
-using Authorization = FortnoxAPILibrary.Entities.Authorization;
+using FortnoxAPILibrary.Entities;
 
 // ReSharper disable UnusedMember.Global
 
@@ -30,9 +29,9 @@ namespace FortnoxAPILibrary.Connectors
 				var wr = SetupRequest(ConnectionSettings.FortnoxAPIServer, authorizationCode, clientSecret);
                 using var response = wr.GetResponse();
                 using var responseStream = response.GetResponseStream();
-                var auth = Deserialize<Authorization>(responseStream.ToText());
-                accessToken = auth.AccessToken;
-            }
+				var authorizationContainer = Deserialize<AuthorizationContainer>(responseStream.ToText());
+				accessToken = authorizationContainer.Authorization.AccessToken;
+			}
 			catch (WebException we)
 			{
 				Error = HandleException(we);

--- a/FortnoxAPILibrary/Entities/Authorization.cs
+++ b/FortnoxAPILibrary/Entities/Authorization.cs
@@ -7,10 +7,19 @@ namespace FortnoxAPILibrary.Entities
 {
     /// <remarks/>
     [Entity(SingularName = "Authorization")]
-    public class Authorization {
-    
+    public class Authorization
+    {
+
         /// <remarks/>
         [JsonProperty]
         public string AccessToken { get; set; }
+    }
+
+    /// <remarks/>
+    public class AuthorizationContainer
+    {
+        /// <remarks/>
+        [JsonProperty]
+        public Authorization Authorization { get; set; }
     }
 }

--- a/FortnoxAPILibrary/Entities/Authorization.cs
+++ b/FortnoxAPILibrary/Entities/Authorization.cs
@@ -14,12 +14,4 @@ namespace FortnoxAPILibrary.Entities
         [JsonProperty]
         public string AccessToken { get; set; }
     }
-
-    /// <remarks/>
-    public class AuthorizationContainer
-    {
-        /// <remarks/>
-        [JsonProperty]
-        public Authorization Authorization { get; set; }
-    }
 }


### PR DESCRIPTION
Seems like GetAccessToken is broken. The returned JSON from the API s this and the current code does not work:

{"Authorization":{"AccessToken":"96e49731-0251-4292-a160-37267bc828e3"}}

This commit fixes the JSON deserialization problem with a outer class called AuthorizationContainer.