### PR TITLE
Update RateLimiter package to 2.2.0

### DIFF
--- a/FortnoxAPILibrary/FortnoxAPILibrary.csproj
+++ b/FortnoxAPILibrary/FortnoxAPILibrary.csproj
@@ -27,7 +27,7 @@
   <ItemGroup>
     <PackageReference Include="MediaTypeMap.Core" Version="2.3.3" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
-    <PackageReference Include="RateLimiter" Version="2.1.0" />
+    <PackageReference Include="RateLimiter" Version="2.2.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Fixes an issue with `IAsyncEnumerable` in ComposableAsync.Core as
described in:
https://github.com/David-Desmaisons/ComposableAsync/issues/5