### PR TITLE
Fix mapping on field OrganizationNumber from api to entity CompanyInformation

### DIFF
--- a/FortnoxSDK.Tests/ConnectorTests/CompanyInformationTests.cs
+++ b/FortnoxSDK.Tests/ConnectorTests/CompanyInformationTests.cs
@@ -39,6 +39,7 @@ namespace FortnoxSDK.Tests.ConnectorTests
 
             var retrievedCompanyInformation = connector.Get();
             Assert.IsNotNull(retrievedCompanyInformation?.CompanyName);
+            Assert.IsNotNull(retrievedCompanyInformation?.OrganizationNumber);
 
             #endregion READ / GET
 

--- a/FortnoxSDK/Entities/Company Information/CompanyInformation.cs
+++ b/FortnoxSDK/Entities/Company Information/CompanyInformation.cs
@@ -35,7 +35,7 @@ namespace Fortnox.SDK.Entities
         ///<summary> Organisation number </summary>
         [ReadOnly]
         [JsonProperty]
-        public string OrganisationNumber { get; private set; }
+        public string OrganizationNumber { get; private set; }
 
         ///<summary> Visit address </summary>
         [ReadOnly]


### PR DESCRIPTION
Fix mapping on field OrganizationNumber from api to entity Companyinformation. Api and sdk currently have different spelling on OrganizationNumber and can therefore not map the field