### PR TITLE
Remove ReadOnly attribute from Article.SalesPrice

### DIFF
--- a/FortnoxSDK.Tests/ConnectorTests/CompanyInformationTests.cs
+++ b/FortnoxSDK.Tests/ConnectorTests/CompanyInformationTests.cs
@@ -39,6 +39,7 @@ namespace FortnoxSDK.Tests.ConnectorTests
 
             var retrievedCompanyInformation = connector.Get();
             Assert.IsNotNull(retrievedCompanyInformation?.CompanyName);
+            Assert.IsNotNull(retrievedCompanyInformation?.OrganizationNumber);
 
             #endregion READ / GET
 

--- a/FortnoxSDK/Entities/Articles/Article.cs
+++ b/FortnoxSDK/Entities/Articles/Article.cs
@@ -103,9 +103,8 @@ namespace Fortnox.SDK.Entities
         public long? SalesAccount { get; set; }
 
         ///<summary> Price of article for its default price list. </summary>
-        [ReadOnly]
         [JsonProperty]
-        public decimal? SalesPrice { get; private set; }
+        public decimal? SalesPrice { get; set; }
 
         ///<summary> If the article is stock goods. </summary>
         [JsonProperty]

--- a/FortnoxSDK/Entities/Company Information/CompanyInformation.cs
+++ b/FortnoxSDK/Entities/Company Information/CompanyInformation.cs
@@ -35,7 +35,7 @@ namespace Fortnox.SDK.Entities
         ///<summary> Organisation number </summary>
         [ReadOnly]
         [JsonProperty]
-        public string OrganisationNumber { get; private set; }
+        public string OrganizationNumber { get; private set; }
 
         ///<summary> Visit address </summary>
         [ReadOnly]


### PR DESCRIPTION
I don't see any reason for the attribute [ReadOnly] on property Article.SalesPrice since the field is accessable directly through the API.

If the Attribute has to stay on the property please explain.

If the pr is accepted I would appriciate if you could do a release as soon as possible :)  

Thanks