### PR TITLE
Add GenerateDocumentationFile

### DIFF
--- a/FortnoxSDK/FortnoxSDK.csproj
+++ b/FortnoxSDK/FortnoxSDK.csproj
@@ -2,21 +2,22 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-	<LangVersion>8</LangVersion>
-	<PackageId>Fortnox.NET.SDK</PackageId>
-	<Version>4.2.0</Version>
-	<Authors>Softwerk AB</Authors>
-	<Company>Softwerk AB</Company>
-	<Description>SDK package for Fortnox API. This package is developed and maintained by Softwerk AB. For more information please visit the repository on Github.</Description>
-	<RepositoryUrl>https://github.com/FortnoxAB/csharp-api-sdk</RepositoryUrl>
-	<PackageIcon>fortnoxLogo.png</PackageIcon>
-	<PackageTags>Fortnox, SDK, API, Client, C#, .NET, REST, Softwerk</PackageTags>
-	<Copyright>Copyright (c) 2021 Softwerk AB</Copyright>
-	<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-	<PackageLicenseExpression>MIT</PackageLicenseExpression>
-	<PackageProjectUrl>https://github.com/FortnoxAB/csharp-api-sdk</PackageProjectUrl>
-	<AssemblyName>FortnoxSDK</AssemblyName>
-	<RootNamespace>Fortnox.SDK</RootNamespace>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <LangVersion>8</LangVersion>
+    <PackageId>Fortnox.NET.SDK</PackageId>
+    <Version>4.2.0</Version>
+    <Authors>Softwerk AB</Authors>
+    <Company>Softwerk AB</Company>
+    <Description>SDK package for Fortnox API. This package is developed and maintained by Softwerk AB. For more information please visit the repository on Github.</Description>
+    <RepositoryUrl>https://github.com/FortnoxAB/csharp-api-sdk</RepositoryUrl>
+    <PackageIcon>fortnoxLogo.png</PackageIcon>
+    <PackageTags>Fortnox, SDK, API, Client, C#, .NET, REST, Softwerk</PackageTags>
+    <Copyright>Copyright (c) 2021 Softwerk AB</Copyright>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <PackageProjectUrl>https://github.com/FortnoxAB/csharp-api-sdk</PackageProjectUrl>
+    <AssemblyName>FortnoxSDK</AssemblyName>
+    <RootNamespace>Fortnox.SDK</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Add `GenerateDocumentationFile` to the csproj file.

The NuGet package seems not to include any XML documentation.