### PR TITLE
Semicolon separate package tags

### DIFF
--- a/FortnoxSDK/FortnoxSDK.csproj
+++ b/FortnoxSDK/FortnoxSDK.csproj
@@ -11,7 +11,7 @@
     <Description>SDK package for Fortnox API. This package is developed and maintained by Softwerk AB. For more information please visit the repository on Github.</Description>
     <RepositoryUrl>https://github.com/FortnoxAB/csharp-api-sdk</RepositoryUrl>
     <PackageIcon>fortnoxLogo.png</PackageIcon>
-    <PackageTags>Fortnox, SDK, API, Client, C#, .NET, REST, Softwerk</PackageTags>
+    <PackageTags>Fortnox;SDK;API;Client;C#;.NET;REST;Softwerk</PackageTags>
     <Copyright>Copyright (c) 2021 Softwerk AB</Copyright>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>


### PR DESCRIPTION
As per https://docs.microsoft.com/en-us/dotnet/standard/library-guidance/nuget#important-nuget-package-metadata

> A space or semicolon-delimited list of tags and keywords that describe the package. Tags are used when searching for packages.