### PR TITLE
Add the Obsolete attribute to the class

### DIFF
--- a/FortnoxSDK/Auth/IAuthWorkflow.cs
+++ b/FortnoxSDK/Auth/IAuthWorkflow.cs
@@ -62,6 +62,7 @@ namespace Fortnox.SDK.Auth
     /// <summary>
     /// Represents methods of a Fortnox legacy auth workflow
     /// </summary>
+    [Obsolete("2021-12-09: End-of-life for the static authorization. Use StandardAuth.")]
     public interface IStaticTokenAuthWorkflow
     {
         /// <summary>

--- a/FortnoxSDK/Authorization/StaticTokenAuth.cs
+++ b/FortnoxSDK/Authorization/StaticTokenAuth.cs
@@ -6,8 +6,8 @@ namespace Fortnox.SDK.Authorization
     /// Handles authorization by non-expirable AccessToken and ClientSecret.
     /// Can only be used for unpublished Fortnox apps/integrations.
     /// </summary>
+    [Obsolete("2021-12-09: End-of-life for the static authorization. Use StandardAuth.")]
     public class StaticTokenAuth : FortnoxAuthorization
-
     {
         public string ClientSecret { get; set; }
 


### PR DESCRIPTION
> 2021-12-09: End of life for the existing authorization flow with long-lived access tokens. All integrations must use the OAuth2 Authorization Code Flow with expiring access tokens.

https://developer.fortnox.se/blog/fortnox/