### PR TITLE
Add a method to generate state

### DIFF
--- a/FortnoxSDK/Auth/IAuthWorkflow.cs
+++ b/FortnoxSDK/Auth/IAuthWorkflow.cs
@@ -61,6 +61,12 @@ namespace Fortnox.SDK.Auth
         Task<TokenInfo> RefreshTokenAsync(string refreshToken, string clientId, string clientSecret);
 
         /// <summary>
+        /// Generates a state nonce for use with the <see cref="BuildAuthUri"/> method.
+        /// </summary>
+        /// <returns>A randomly-generated string.</returns>
+        string GenerateState();
+
+        /// <summary>
         /// Use this function to build the full URI for OAuth 2.0 workflow initialization.
         /// </summary>
         /// <param name="clientId">Client id given to you by Fortnox.</param>

--- a/FortnoxSDK/Auth/StandardAuthWorkflow.cs
+++ b/FortnoxSDK/Auth/StandardAuthWorkflow.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Net.Http;
+using System.Security.Cryptography;
 using System.Text;
 using System.Threading.Tasks;
 using Fortnox.SDK.Connectors.Base;
@@ -71,6 +72,20 @@ namespace Fortnox.SDK.Auth
             var tokenInfo = Serializer.Deserialize<TokenInfo>(responseJson);
 
             return tokenInfo;
+        }
+
+        public string GenerateState()
+        {
+            var data = new byte[32];
+
+            using (var rng = new RNGCryptoServiceProvider())
+            {
+                rng.GetBytes(data);
+            }
+
+            var state = Convert.ToBase64String(data).Replace('+', '-').Replace('/', '-').Replace('=', '-');
+
+            return state;
         }
 
         public Uri BuildAuthUri(string clientId, IEnumerable<Scope> scopes, string state, string redirectUri = null)

--- a/FortnoxSDK/Auth/StandardAuthWorkflow.cs
+++ b/FortnoxSDK/Auth/StandardAuthWorkflow.cs
@@ -78,10 +78,8 @@ namespace Fortnox.SDK.Auth
         {
             var data = new byte[32];
 
-            using (var rng = new RNGCryptoServiceProvider())
-            {
-                rng.GetBytes(data);
-            }
+            using var rng = new RNGCryptoServiceProvider()
+            rng.GetBytes(data);
 
             var state = Convert.ToBase64String(data).Replace('+', '-').Replace('/', '-').Replace('=', '-');
 


### PR DESCRIPTION
This adds the `GenerateState` method to the auth workflow.

The method makes use of [`RNGCryptoServiceProvider`](https://docs.microsoft.com/en-us/dotnet/api/system.security.cryptography.rngcryptoserviceprovider?view=net-5.0) to securely generate random numbers which then gets converted into a base64 encoded string and then replaces the characters `+` and `/` and `=` in order to make it URL safe.