### PR TITLE
Add VAT code property to AccountSubset

### DIFF
--- a/FortnoxSDK/Entities.Subsets/AccountSubset.cs
+++ b/FortnoxSDK/Entities.Subsets/AccountSubset.cs
@@ -55,5 +55,9 @@ namespace Fortnox.SDK.Entities
         [ReadOnly]
         [JsonProperty]
         public long? Year { get; private set; }
+
+        /// <summary> VAT code </summary>
+        [JsonProperty]
+        public string VATCode { get; set; }
     }
 }


### PR DESCRIPTION
Verified as being part of the data by calling the API, and is also listed in the docs here:
https://apps.fortnox.se/apidocs#operation/list_AccountsResource

It seems the docs at "apps.fortnox.se" are the most up to date ones.
In the old(?) docs at https://developer.fortnox.se/documentation/resources/accounts/#List-all-accounts you can see `VATCode` is missing, despite being in the response when calling the API.

There may be other properties missing due to this mismatch in API docs.