### PR TITLE
Trim padding and increase entropy

### DIFF
--- a/FortnoxSDK/Auth/StandardAuthWorkflow.cs
+++ b/FortnoxSDK/Auth/StandardAuthWorkflow.cs
@@ -81,7 +81,7 @@ namespace Fortnox.SDK.Auth
             using var rng = new RNGCryptoServiceProvider();
             rng.GetBytes(data);
 
-            var state = Convert.ToBase64String(data).Replace('+', '-').Replace('/', '-').Replace('=', '-');
+            var state = Convert.ToBase64String(data).Replace('+', '-').Replace('/', '_').TrimEnd('=');
 
             return state;
         }


### PR DESCRIPTION
By having different replacement characters for `+` and `/` we increase entropy.
We remove the trailing `=` since its only used for padding in Base64.