### PR TITLE
Rename APIConstants to ApiConstants

### DIFF
--- a/FortnoxSDK.Tests/BaseConnectorTests.cs
+++ b/FortnoxSDK.Tests/BaseConnectorTests.cs
@@ -185,7 +185,7 @@ namespace FortnoxSDK.Tests
             Assert.IsTrue(result.TotalPages > 1);
 
             var searchSettings = new CustomerSearch();
-            searchSettings.Limit = APIConstants.Unlimited;
+            searchSettings.Limit = ApiConstants.Unlimited;
             var allInOneResult = await connector.FindAsync(searchSettings);
 
             Assert.AreEqual(1, allInOneResult.TotalPages);

--- a/FortnoxSDK.Tests/ConnectorTests/EmployeeTests.cs
+++ b/FortnoxSDK.Tests/ConnectorTests/EmployeeTests.cs
@@ -84,7 +84,7 @@ namespace FortnoxSDK.Tests.ConnectorTests
 
             var searchSettings = new EmployeeSearch();
             //searchSettings.LastModified = TestUtils.Recently; //parameter is not accepted by server
-            searchSettings.Limit = APIConstants.Unlimited;
+            searchSettings.Limit = ApiConstants.Unlimited;
             var employees = await connector.FindAsync(searchSettings);
 
             var newEmployees = employees.Entities.Where(e => e.City == marks).ToList();

--- a/FortnoxSDK.Tests/ConnectorTests/ExpenseTests.cs
+++ b/FortnoxSDK.Tests/ConnectorTests/ExpenseTests.cs
@@ -84,7 +84,7 @@ namespace FortnoxSDK.Tests.ConnectorTests
 
             var searchSettings = new ExpenseSearch();
             searchSettings.LastModified = TestUtils.Recently; //does not seem to work
-            searchSettings.Limit = APIConstants.Unlimited;
+            searchSettings.Limit = ApiConstants.Unlimited;
             var expensesCollection = await connector.FindAsync(searchSettings);
 
             var newExpenses = expensesCollection.Entities.Where(x => x.Text == remark).ToList();

--- a/FortnoxSDK.Tests/ConnectorTests/InvoicePaymentTests.cs
+++ b/FortnoxSDK.Tests/ConnectorTests/InvoicePaymentTests.cs
@@ -51,7 +51,7 @@ namespace FortnoxSDK.Tests.ConnectorTests
             };
 
             var createdInvoicePayment = await connector.CreateAsync(newInvoicePayment);
-            Assert.AreEqual("2020-02-01", createdInvoicePayment.PaymentDate?.ToString(APIConstants.DateFormat));
+            Assert.AreEqual("2020-02-01", createdInvoicePayment.PaymentDate?.ToString(ApiConstants.DateFormat));
 
             #endregion CREATE
 
@@ -60,14 +60,14 @@ namespace FortnoxSDK.Tests.ConnectorTests
             createdInvoicePayment.PaymentDate = new DateTime(2020, 3, 1);
 
             var updatedInvoicePayment = await connector.UpdateAsync(createdInvoicePayment);
-            Assert.AreEqual("2020-03-01", updatedInvoicePayment.PaymentDate?.ToString(APIConstants.DateFormat));
+            Assert.AreEqual("2020-03-01", updatedInvoicePayment.PaymentDate?.ToString(ApiConstants.DateFormat));
 
             #endregion UPDATE
 
             #region READ / GET
 
             var retrievedInvoicePayment = await connector.GetAsync(createdInvoicePayment.Number);
-            Assert.AreEqual("2020-03-01", retrievedInvoicePayment.PaymentDate?.ToString(APIConstants.DateFormat));
+            Assert.AreEqual("2020-03-01", retrievedInvoicePayment.PaymentDate?.ToString(ApiConstants.DateFormat));
 
             #endregion READ / GET
 

--- a/FortnoxSDK.Tests/ConnectorTests/InvoiceTests.cs
+++ b/FortnoxSDK.Tests/ConnectorTests/InvoiceTests.cs
@@ -163,8 +163,8 @@ namespace FortnoxSDK.Tests.ConnectorTests
             };
 
             var createdInvoice = await connector.CreateAsync(newInvoice);
-            Assert.AreEqual("2019-01-20", createdInvoice.InvoiceDate?.ToString(APIConstants.DateFormat));
-            Assert.AreEqual("2019-02-19", createdInvoice.DueDate?.ToString(APIConstants.DateFormat));
+            Assert.AreEqual("2019-01-20", createdInvoice.InvoiceDate?.ToString(ApiConstants.DateFormat));
+            Assert.AreEqual("2019-02-19", createdInvoice.DueDate?.ToString(ApiConstants.DateFormat));
 
             var newInvoiceDate = new DateTime(2019, 1, 1);
             var dateChange = newInvoiceDate - newInvoice.InvoiceDate.Value;
@@ -174,8 +174,8 @@ namespace FortnoxSDK.Tests.ConnectorTests
             createdInvoice.DueDate = newDueDate;
 
             var updatedInvoice = await connector.UpdateAsync(createdInvoice);
-            Assert.AreEqual("2019-01-01", updatedInvoice.InvoiceDate?.ToString(APIConstants.DateFormat));
-            Assert.AreEqual("2019-01-31", updatedInvoice.DueDate?.ToString(APIConstants.DateFormat));
+            Assert.AreEqual("2019-01-01", updatedInvoice.InvoiceDate?.ToString(ApiConstants.DateFormat));
+            Assert.AreEqual("2019-01-31", updatedInvoice.DueDate?.ToString(ApiConstants.DateFormat));
 
             await connector.CancelAsync(createdInvoice.DocumentNumber);
 

--- a/FortnoxSDK/APIConstants.cs
+++ b/FortnoxSDK/APIConstants.cs
@@ -1,16 +1,15 @@
 ﻿// ReSharper disable UnusedMember.Global
 namespace Fortnox.SDK
 {
-	/// <remarks/>
-	public class APIConstants
+	public class ApiConstants
     {
-        //TODO: Temporary constant - remove when not needed anymore
-        internal const string ObsoleteSyncMethodWarning = @"Method will be removed. Use async variant. If it does't exist, report an issue. See https://github.com/FortnoxAB/csharp-api-sdk/issues/180";
+        // TODO: Temporary constant - remove when not needed anymore
+        internal const string ObsoleteSyncMethodWarning = @"Method will be removed. Use async variant. If it doesn't exist, report an issue. See https://github.com/FortnoxAB/csharp-api-sdk/issues/180";
 
         /// <summary>
-        /// Base URI of Fortnox API server
+        /// Base URI of Fortnox API server.
         /// </summary>
-        public const string FortnoxApi = @"https://api.fortnox.se";
+        public const string FortnoxApi = "https://api.fortnox.se";
 
 		/// <summary>
 		/// Use this to make a field blank in Fortnox.
@@ -18,20 +17,20 @@ namespace Fortnox.SDK
 		public const string BlankValue = "API_BLANK";
 
         /// <summary>
-        /// Use this to format date to a string
+        /// Use this to format date to a string.
         /// </summary>
         public const string DateFormat = "yyyy-MM-dd";
 
         /// <summary>
-        /// Use this to format date with time to a string
+        /// Use this to format date with time to a string.
         /// </summary>
         public const string DateAndTimeFormat = "yyyy-MM-dd HH:mm:ss";
 
         /// <summary>
-        /// Maximal page size (limit) offered by the API
-        /// Use with Limit field in search settings
+        /// Maximal page size (limit) offered by the API.
+        /// Use with Limit field in search settings.
         /// </summary>
-        public const int MaxLimit = 500; //Max limit
+        public const int MaxLimit = 500;
 
         /// <summary>
         /// Unlimited page size. This setting is not supported by the server API.

--- a/FortnoxSDK/Auth/IAuthWorkflow.cs
+++ b/FortnoxSDK/Auth/IAuthWorkflow.cs
@@ -22,7 +22,7 @@ namespace Fortnox.SDK.Auth
         /// <para>The authorization code is valid for 10 minutes. It can only be used once.</para>
         /// <para>The token is valid for 10 minutes. It can be re-used several times.</para>
         /// </remarks>
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
         TokenInfo GetToken(string authCode, string clientId, string clientSecret, string redirectUri = null);
 
         /// <summary>
@@ -48,7 +48,7 @@ namespace Fortnox.SDK.Auth
         /// <param name="clientSecret">Client secret given to you by Fortnox.</param>
         /// <returns>OAuth 2 token information.</returns>
         /// <remarks>The refresh token is valid for 30 days. It can only be used once.</remarks>
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
         TokenInfo RefreshToken(string refreshToken, string clientId, string clientSecret);
 
         /// <summary>
@@ -94,7 +94,7 @@ namespace Fortnox.SDK.Auth
         /// <param name="clientSecret">The Client-Secret code given to you by Fortnox.</param>
         /// <returns>The Access-Token to use with Fortnox.</returns>
         /// <remarks>Note that an authorization-code can be used only once. Save the retrieved Access-Token in order to use it for FortnoxClient.</remarks>
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
         string GetToken(string authCode, string clientSecret);
 
         /// <summary>

--- a/FortnoxSDK/Connectors/AbsenceTransactionConnector.cs
+++ b/FortnoxSDK/Connectors/AbsenceTransactionConnector.cs
@@ -79,7 +79,7 @@ namespace Fortnox.SDK.Connectors
 		}
 		public async Task DeleteAsync(string employeeId, DateTime? date, AbsenceCauseCode? code)
 		{
-			await BaseDelete(employeeId, date?.ToString(APIConstants.DateFormat), code?.GetStringValue()).ConfigureAwait(false);
+			await BaseDelete(employeeId, date?.ToString(ApiConstants.DateFormat), code?.GetStringValue()).ConfigureAwait(false);
 		}
 		public async Task<AbsenceTransaction> CreateAsync(AbsenceTransaction absenceTransaction)
 		{
@@ -87,11 +87,11 @@ namespace Fortnox.SDK.Connectors
 		}
 		public async Task<AbsenceTransaction> UpdateAsync(AbsenceTransaction absenceTransaction)
 		{
-			return await BaseUpdate(absenceTransaction, absenceTransaction.EmployeeId, absenceTransaction.Date?.ToString(APIConstants.DateFormat), absenceTransaction.CauseCode?.GetStringValue()).ConfigureAwait(false);
+			return await BaseUpdate(absenceTransaction, absenceTransaction.EmployeeId, absenceTransaction.Date?.ToString(ApiConstants.DateFormat), absenceTransaction.CauseCode?.GetStringValue()).ConfigureAwait(false);
 		}
         public async Task<AbsenceTransaction> GetAsync(string employeeId, DateTime? date, AbsenceCauseCode? code)
 		{
-			return await BaseGet(employeeId, date?.ToString(APIConstants.DateFormat), code?.GetStringValue()).ConfigureAwait(false);
+			return await BaseGet(employeeId, date?.ToString(ApiConstants.DateFormat), code?.GetStringValue()).ConfigureAwait(false);
 		}
 	}
 }

--- a/FortnoxSDK/Connectors/AttendanceTransactionsConnector.cs
+++ b/FortnoxSDK/Connectors/AttendanceTransactionsConnector.cs
@@ -78,7 +78,7 @@ namespace Fortnox.SDK.Connectors
         }
         public async Task DeleteAsync(string employeeId, DateTime? date, AttendanceCauseCode? code)
         {
-            await BaseDelete(employeeId, date?.ToString(APIConstants.DateFormat), code?.GetStringValue()).ConfigureAwait(false);
+            await BaseDelete(employeeId, date?.ToString(ApiConstants.DateFormat), code?.GetStringValue()).ConfigureAwait(false);
         }
         public async Task<AttendanceTransaction> CreateAsync(AttendanceTransaction attendanceTransaction)
         {
@@ -86,11 +86,11 @@ namespace Fortnox.SDK.Connectors
         }
         public async Task<AttendanceTransaction> UpdateAsync(AttendanceTransaction attendanceTransaction)
         {
-            return await BaseUpdate(attendanceTransaction, attendanceTransaction.EmployeeId, attendanceTransaction.Date?.ToString(APIConstants.DateFormat), attendanceTransaction.CauseCode?.GetStringValue()).ConfigureAwait(false);
+            return await BaseUpdate(attendanceTransaction, attendanceTransaction.EmployeeId, attendanceTransaction.Date?.ToString(ApiConstants.DateFormat), attendanceTransaction.CauseCode?.GetStringValue()).ConfigureAwait(false);
         }
         public async Task<AttendanceTransaction> GetAsync(string employeeId, DateTime? date, AttendanceCauseCode? code)
         {
-            return await BaseGet(employeeId, date?.ToString(APIConstants.DateFormat), code?.GetStringValue()).ConfigureAwait(false);
+            return await BaseGet(employeeId, date?.ToString(ApiConstants.DateFormat), code?.GetStringValue()).ConfigureAwait(false);
         }
 	}
 }

--- a/FortnoxSDK/Connectors/Base/SearchableEntityConnector.cs
+++ b/FortnoxSDK/Connectors/Base/SearchableEntityConnector.cs
@@ -26,7 +26,7 @@ namespace Fortnox.SDK.Connectors.Base
         
         protected async Task<EntityCollection<T>> SendAsync<T>(SearchRequest<T> request)
         {
-            if (request.SearchSettings != null && request.SearchSettings.Limit == APIConstants.Unlimited)
+            if (request.SearchSettings != null && request.SearchSettings.Limit == ApiConstants.Unlimited)
                 return await GetAllInOnePage(request).ConfigureAwait(false);
             else
                 return await GetSinglePage(request).ConfigureAwait(false);
@@ -40,7 +40,7 @@ namespace Fortnox.SDK.Connectors.Base
             {
                 var singlePageRequest = Clone(request);
                 singlePageRequest.SearchSettings.Page = page;
-                singlePageRequest.SearchSettings.Limit = APIConstants.MaxLimit;
+                singlePageRequest.SearchSettings.Limit = ApiConstants.MaxLimit;
 
                 var result = await GetSinglePage(singlePageRequest).ConfigureAwait(false);
                 allEntities.AddRange(result.Entities);

--- a/FortnoxSDK/Connectors/SIEConnector.cs
+++ b/FortnoxSDK/Connectors/SIEConnector.cs
@@ -46,9 +46,9 @@ namespace Fortnox.SDK.Connectors
             var parameters = new Dictionary<string, string>();
 
             if (exportOptions.FromDate != null)
-                parameters.Add("fromdate", exportOptions.FromDate?.ToString(APIConstants.DateFormat));
+                parameters.Add("fromdate", exportOptions.FromDate?.ToString(ApiConstants.DateFormat));
             if (exportOptions.ToDate != null)
-                parameters.Add("todate", exportOptions.ToDate?.ToString(APIConstants.DateFormat));
+                parameters.Add("todate", exportOptions.ToDate?.ToString(ApiConstants.DateFormat));
             if (exportOptions.ExportAll != null)
                 parameters.Add("exportall", exportOptions.ExportAll.ToString().ToLower());
             if (exportOptions.Selection != null)

--- a/FortnoxSDK/Connectors/ScheduleTimesConnector.cs
+++ b/FortnoxSDK/Connectors/ScheduleTimesConnector.cs
@@ -58,15 +58,15 @@ namespace Fortnox.SDK.Connectors
 
         public async Task<ScheduleTimes> ResetAsync(string employeeId, DateTime? date)
         {
-            return await BaseUpdate(null, employeeId, date?.ToString(APIConstants.DateFormat), "resetday").ConfigureAwait(false);
+            return await BaseUpdate(null, employeeId, date?.ToString(ApiConstants.DateFormat), "resetday").ConfigureAwait(false);
         }
         public async Task<ScheduleTimes> UpdateAsync(ScheduleTimes scheduleTime)
         {
-            return await BaseUpdate(scheduleTime,scheduleTime.EmployeeId, scheduleTime.Date?.ToString(APIConstants.DateFormat)).ConfigureAwait(false);
+            return await BaseUpdate(scheduleTime,scheduleTime.EmployeeId, scheduleTime.Date?.ToString(ApiConstants.DateFormat)).ConfigureAwait(false);
         }
 		public async Task<ScheduleTimes> GetAsync(string employeeId, DateTime? date)
         {
-            return await BaseGet(employeeId, date?.ToString(APIConstants.DateFormat)).ConfigureAwait(false);
+            return await BaseGet(employeeId, date?.ToString(ApiConstants.DateFormat)).ConfigureAwait(false);
         }
 		public async Task<EntityCollection<ScheduleTimes>> FindAsync(ScheduleTimesSearch searchSettings)
 		{

--- a/FortnoxSDK/Entities.Shared/HouseworkType.cs
+++ b/FortnoxSDK/Entities.Shared/HouseworkType.cs
@@ -71,7 +71,7 @@ namespace Fortnox.SDK.Entities
         /// <summary>
         /// Use with Update request to clear existing value
         /// </summary>
-        [EnumMember(Value = APIConstants.BlankValue)]
+        [EnumMember(Value = ApiConstants.BlankValue)]
         Blank
     }
 }

--- a/FortnoxSDK/Interfaces/IAbsenceTransactionConnector.cs
+++ b/FortnoxSDK/Interfaces/IAbsenceTransactionConnector.cs
@@ -9,15 +9,15 @@ namespace Fortnox.SDK.Interfaces
     /// <remarks/>
     public interface IAbsenceTransactionConnector : IEntityConnector
 	{
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
 		AbsenceTransaction Update(AbsenceTransaction absenceTransaction);
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
 		AbsenceTransaction Create(AbsenceTransaction absenceTransaction);
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
 		AbsenceTransaction Get(string employeeId, DateTime? date, AbsenceCauseCode? code);
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
 		void Delete(string employeeId, DateTime? date, AbsenceCauseCode? code);
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
 		EntityCollection<AbsenceTransaction> Find(AbsenceTransactionSearch searchSettings);
 
 		Task<AbsenceTransaction> UpdateAsync(AbsenceTransaction absenceTransaction);

--- a/FortnoxSDK/Interfaces/IAccountChartConnector.cs
+++ b/FortnoxSDK/Interfaces/IAccountChartConnector.cs
@@ -9,7 +9,7 @@ namespace Fortnox.SDK.Interfaces
     /// <remarks/>
     public interface IAccountChartConnector : IEntityConnector
 	{
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
 		EntityCollection<AccountChart> Find(AccountChartSearch searchSettings);
 
 		Task<EntityCollection<AccountChart>> FindAsync(AccountChartSearch searchSettings);

--- a/FortnoxSDK/Interfaces/IAccountConnector.cs
+++ b/FortnoxSDK/Interfaces/IAccountConnector.cs
@@ -9,15 +9,15 @@ namespace Fortnox.SDK.Interfaces
     /// <remarks/>
     public interface IAccountConnector : IEntityConnector
 	{
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
 		Account Update(Account account, long? finYearID = null);
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
 		Account Create(Account account, long? finYearID = null);
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
 		Account Get(long? id, long? finYearID = null);
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
 		void Delete(long? id, long? finYearID = null);
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
 		EntityCollection<AccountSubset> Find(AccountSearch searchSettings);
 
 		Task<Account> UpdateAsync(Account account, long? finYearID = null);

--- a/FortnoxSDK/Interfaces/IArchiveConnector.cs
+++ b/FortnoxSDK/Interfaces/IArchiveConnector.cs
@@ -8,17 +8,17 @@ namespace Fortnox.SDK.Interfaces
 {
     public interface IArchiveConnector : IEntityConnector
 	{
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
         byte[] DownloadFile(string id, IdType idType = IdType.Id);
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
         FileInfo DownloadFile(string id, string localPath, IdType idType = IdType.Id);
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
         ArchiveFile UploadFile(string name, byte[] data, string folderPathOrId = null);
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
         ArchiveFile UploadFile(string name, Stream stream, string folderPathOrId = null);
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
         ArchiveFile UploadFile(string localPath, string folderPathOrId = null);
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
         void DeleteFile(string id);
 
         ArchiveFolder GetFolder(string pathOrId = null);

--- a/FortnoxSDK/Interfaces/IArticleConnector.cs
+++ b/FortnoxSDK/Interfaces/IArticleConnector.cs
@@ -9,15 +9,15 @@ namespace Fortnox.SDK.Interfaces
     /// <remarks/>
     public interface IArticleConnector : IEntityConnector
 	{
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
 		Article Update(Article article);
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
 		Article Create(Article article);
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
 		Article Get(string id);
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
 		void Delete(string id);
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
 		EntityCollection<ArticleSubset> Find(ArticleSearch searchSettings);
 
 		Task<Article> UpdateAsync(Article article);

--- a/FortnoxSDK/Interfaces/IArticleFileConnectionConnector.cs
+++ b/FortnoxSDK/Interfaces/IArticleFileConnectionConnector.cs
@@ -9,13 +9,13 @@ namespace Fortnox.SDK.Interfaces
     /// <remarks/>
     public interface IArticleFileConnectionConnector : IEntityConnector
 	{
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
 		ArticleFileConnection Create(ArticleFileConnection articleFileConnection);
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
 		ArticleFileConnection Get(string id);
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
 		void Delete(string id);
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
 		EntityCollection<ArticleFileConnection> Find(ArticleFileConnectionSearch searchSettings);
 
 		Task<ArticleFileConnection> CreateAsync(ArticleFileConnection articleFileConnection);

--- a/FortnoxSDK/Interfaces/IAssetConnector.cs
+++ b/FortnoxSDK/Interfaces/IAssetConnector.cs
@@ -9,15 +9,15 @@ namespace Fortnox.SDK.Interfaces
     /// <remarks/>
     public interface IAssetConnector : IEntityConnector
 	{
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
 		Asset Update(Asset asset);
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
 		Asset Create(Asset asset);
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
 		Asset Get(string id);
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
 		void Delete(string id);
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
 		EntityCollection<AssetSubset> Find(AssetSearch searchSettings);
 
 		Task<Asset> UpdateAsync(Asset asset);

--- a/FortnoxSDK/Interfaces/IAssetFileConnectionConnector.cs
+++ b/FortnoxSDK/Interfaces/IAssetFileConnectionConnector.cs
@@ -9,13 +9,13 @@ namespace Fortnox.SDK.Interfaces
     /// <remarks/>
     public interface IAssetFileConnectionConnector : IEntityConnector
 	{
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
 		AssetFileConnection Create(AssetFileConnection assetFileConnection);
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
 		AssetFileConnection Get(string id);
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
 		void Delete(string id);
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
 		EntityCollection<AssetFileConnection> Find(AssetFileConnectionSearch searchSettings);
 
         Task<AssetFileConnection> CreateAsync(AssetFileConnection assetFileConnection);

--- a/FortnoxSDK/Interfaces/IAssetTypesConnector.cs
+++ b/FortnoxSDK/Interfaces/IAssetTypesConnector.cs
@@ -9,15 +9,15 @@ namespace Fortnox.SDK.Interfaces
     /// <remarks/>
     public interface IAssetTypesConnector : IEntityConnector
 	{
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
 		AssetType Update(AssetType assetType);
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
 		AssetType Create(AssetType assetType);
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
 		AssetType Get(long? id);
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
 		void Delete(long? id);
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
 		EntityCollection<AssetTypesSubset> Find(AssetTypesSearch searchSettings);
 
 		Task<AssetType> UpdateAsync(AssetType assetType);

--- a/FortnoxSDK/Interfaces/IAttendanceTransactionsConnector.cs
+++ b/FortnoxSDK/Interfaces/IAttendanceTransactionsConnector.cs
@@ -9,15 +9,15 @@ namespace Fortnox.SDK.Interfaces
     /// <remarks/>
     public interface IAttendanceTransactionsConnector : IEntityConnector
 	{
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
 		AttendanceTransaction Update(AttendanceTransaction attendanceTransaction);
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
 		AttendanceTransaction Create(AttendanceTransaction attendanceTransaction);
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
 		AttendanceTransaction Get(string employeeId, DateTime? date, AttendanceCauseCode? code);
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
 		void Delete(string employeeId, DateTime? date, AttendanceCauseCode? code);
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
 		EntityCollection<AttendanceTransactionSubset> Find(AttendanceTransactionsSearch searchSettings);
 
 		Task<AttendanceTransaction> UpdateAsync(AttendanceTransaction attendanceTransaction);

--- a/FortnoxSDK/Interfaces/ICompanyInformationConnector.cs
+++ b/FortnoxSDK/Interfaces/ICompanyInformationConnector.cs
@@ -8,7 +8,7 @@ namespace Fortnox.SDK.Interfaces
     /// <remarks/>
     public interface ICompanyInformationConnector : IEntityConnector
 	{
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
         CompanyInformation Get();
 
 		Task<CompanyInformation> GetAsync();

--- a/FortnoxSDK/Interfaces/ICompanySettingsConnector.cs
+++ b/FortnoxSDK/Interfaces/ICompanySettingsConnector.cs
@@ -8,7 +8,7 @@ namespace Fortnox.SDK.Interfaces
     /// <remarks/>
     public interface ICompanySettingsConnector : IEntityConnector
 	{
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
         CompanySettings Get();
 
 		Task<CompanySettings> GetAsync();

--- a/FortnoxSDK/Interfaces/IContractAccrualConnector.cs
+++ b/FortnoxSDK/Interfaces/IContractAccrualConnector.cs
@@ -9,15 +9,15 @@ namespace Fortnox.SDK.Interfaces
     /// <remarks/>
     public interface IContractAccrualConnector : IEntityConnector
 	{
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
 		ContractAccrual Update(ContractAccrual contractAccrual);
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
 		ContractAccrual Create(ContractAccrual contractAccrual);
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
 		ContractAccrual Get(long? id);
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
 		void Delete(long? id);
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
 		EntityCollection<ContractAccrualSubset> Find(ContractAccrualSearch searchSettings);
 
 		Task<ContractAccrual> UpdateAsync(ContractAccrual contractAccrual);

--- a/FortnoxSDK/Interfaces/IContractConnector.cs
+++ b/FortnoxSDK/Interfaces/IContractConnector.cs
@@ -9,19 +9,19 @@ namespace Fortnox.SDK.Interfaces
     /// <remarks/>
     public interface IContractConnector : IEntityConnector
 	{
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
 		Contract Update(Contract contract);
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
 		Contract Create(Contract contract);
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
 		Contract Get(long? id);
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
 		EntityCollection<ContractSubset> Find(ContractSearch searchSettings);
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
 		Contract Finish(long? id);
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
 		Contract CreateInvoice(long? id);
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
         Contract IncreaseInvoiceCount(long? id);
 
 		Task<Contract> UpdateAsync(Contract contract);

--- a/FortnoxSDK/Interfaces/IContractTemplateConnector.cs
+++ b/FortnoxSDK/Interfaces/IContractTemplateConnector.cs
@@ -9,13 +9,13 @@ namespace Fortnox.SDK.Interfaces
     /// <remarks/>
     public interface IContractTemplateConnector : IEntityConnector
 	{
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
 		ContractTemplate Update(ContractTemplate contractTemplate);
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
 		ContractTemplate Create(ContractTemplate contractTemplate);
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
 		ContractTemplate Get(string id);
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
 		EntityCollection<ContractTemplateSubset> Find(ContractTemplateSearch searchSettings);
 
 		Task<ContractTemplate> UpdateAsync(ContractTemplate contractTemplate);

--- a/FortnoxSDK/Interfaces/ICostCenterConnector.cs
+++ b/FortnoxSDK/Interfaces/ICostCenterConnector.cs
@@ -9,15 +9,15 @@ namespace Fortnox.SDK.Interfaces
     /// <remarks/>
     public interface ICostCenterConnector : IEntityConnector
 	{
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
 		CostCenter Update(CostCenter costCenter);
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
 		CostCenter Create(CostCenter costCenter);
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
 		CostCenter Get(string id);
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
 		void Delete(string id);
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
 		EntityCollection<CostCenter> Find(CostCenterSearch searchSettings);
 
 		Task<CostCenter> UpdateAsync(CostCenter costCenter);

--- a/FortnoxSDK/Interfaces/ICurrencyConnector.cs
+++ b/FortnoxSDK/Interfaces/ICurrencyConnector.cs
@@ -9,15 +9,15 @@ namespace Fortnox.SDK.Interfaces
     /// <remarks/>
     public interface ICurrencyConnector : IEntityConnector
 	{
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
 		Currency Update(Currency currency);
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
 		Currency Create(Currency currency);
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
 		Currency Get(string id);
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
 		void Delete(string id);
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
 		EntityCollection<Currency> Find(CurrencySearch searchSettings);
 
 		Task<Currency> UpdateAsync(Currency currency);

--- a/FortnoxSDK/Interfaces/ICustomerConnector.cs
+++ b/FortnoxSDK/Interfaces/ICustomerConnector.cs
@@ -9,15 +9,15 @@ namespace Fortnox.SDK.Interfaces
     /// <remarks/>
     public interface ICustomerConnector : IEntityConnector
 	{
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
 		Customer Update(Customer customer);
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
 		Customer Create(Customer customer);
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
 		Customer Get(string id);
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
 		void Delete(string id);
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
 		EntityCollection<CustomerSubset> Find(CustomerSearch searchSettings);
 
 		Task<Customer> UpdateAsync(Customer customer);

--- a/FortnoxSDK/Interfaces/IEmployeeConnector.cs
+++ b/FortnoxSDK/Interfaces/IEmployeeConnector.cs
@@ -9,13 +9,13 @@ namespace Fortnox.SDK.Interfaces
     /// <remarks/>
     public interface IEmployeeConnector : IEntityConnector
 	{
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
 		Employee Update(Employee employee);
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
 		Employee Create(Employee employee);
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
 		Employee Get(string id);
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
 		EntityCollection<EmployeeSubset> Find(EmployeeSearch searchSettings);
 
 		Task<Employee> UpdateAsync(Employee employee);

--- a/FortnoxSDK/Interfaces/IExpenseConnector.cs
+++ b/FortnoxSDK/Interfaces/IExpenseConnector.cs
@@ -9,11 +9,11 @@ namespace Fortnox.SDK.Interfaces
     /// <remarks/>
     public interface IExpenseConnector : IEntityConnector
 	{
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
         Expense Create(Expense expense);
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
         Expense Get(string id);
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
         EntityCollection<ExpenseSubset> Find(ExpenseSearch searchSettings);
 
         Task<Expense> CreateAsync(Expense expense);

--- a/FortnoxSDK/Interfaces/IFinancialYearConnector.cs
+++ b/FortnoxSDK/Interfaces/IFinancialYearConnector.cs
@@ -9,11 +9,11 @@ namespace Fortnox.SDK.Interfaces
     /// <remarks/>
     public interface IFinancialYearConnector : IEntityConnector
 	{
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
         FinancialYear Create(FinancialYear financialYear);
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
         FinancialYear Get(long? id);
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
         EntityCollection<FinancialYearSubset> Find(FinancialYearSearch searchSettings);
 
         Task<FinancialYear> CreateAsync(FinancialYear financialYear);

--- a/FortnoxSDK/Interfaces/IInvoiceAccrualConnector.cs
+++ b/FortnoxSDK/Interfaces/IInvoiceAccrualConnector.cs
@@ -9,15 +9,15 @@ namespace Fortnox.SDK.Interfaces
     /// <remarks/>
     public interface IInvoiceAccrualConnector : IEntityConnector
 	{
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
 		InvoiceAccrual Update(InvoiceAccrual invoiceAccrual);
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
 		InvoiceAccrual Create(InvoiceAccrual invoiceAccrual);
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
 		InvoiceAccrual Get(long? id);
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
 		void Delete(long? id);
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
 		EntityCollection<InvoiceAccrualSubset> Find(InvoiceAccrualSearch searchSettings);
 
 		Task<InvoiceAccrual> UpdateAsync(InvoiceAccrual invoiceAccrual);

--- a/FortnoxSDK/Interfaces/IInvoiceConnector.cs
+++ b/FortnoxSDK/Interfaces/IInvoiceConnector.cs
@@ -9,31 +9,31 @@ namespace Fortnox.SDK.Interfaces
     /// <remarks/>
     public interface IInvoiceConnector : IEntityConnector
 	{
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
         Invoice Update(Invoice invoice);
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
         Invoice Create(Invoice invoice);
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
         Invoice Get(long? id);
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
         EntityCollection<InvoiceSubset> Find(InvoiceSearch searchSettings);
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
         Invoice Bookkeep(long? id);
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
         Invoice Cancel(long? id);
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
         Invoice CreditInvoice(long? id);
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
         Invoice Email(long? id);
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
         Invoice EInvoice(long? id);
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
         byte[] Print(long? id);
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
         byte[] PrintReminder(long? id);
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
         Invoice ExternalPrint(long? id);
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
         byte[] Preview(long? id);
 
 		Task<Invoice> UpdateAsync(Invoice invoice);

--- a/FortnoxSDK/Interfaces/IInvoiceFileConnectionConnector.cs
+++ b/FortnoxSDK/Interfaces/IInvoiceFileConnectionConnector.cs
@@ -9,13 +9,13 @@ namespace Fortnox.SDK.Interfaces
     /// <remarks/>
     public interface IInvoiceFileConnectionConnector : IEntityConnector
 	{
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
         InvoiceFileConnection Update(InvoiceFileConnection invoiceFileConnection);
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
         InvoiceFileConnection Create(InvoiceFileConnection invoiceFileConnection);
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
         void Delete(string id);
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
         IList<InvoiceFileConnection> GetConnections(long? entityId, EntityType? entityType);
 
 		Task<InvoiceFileConnection> UpdateAsync(InvoiceFileConnection invoiceFileConnection);

--- a/FortnoxSDK/Interfaces/IInvoicePaymentConnector.cs
+++ b/FortnoxSDK/Interfaces/IInvoicePaymentConnector.cs
@@ -9,17 +9,17 @@ namespace Fortnox.SDK.Interfaces
     /// <remarks/>
     public interface IInvoicePaymentConnector : IEntityConnector
 	{
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
 		InvoicePayment Update(InvoicePayment invoicePayment);
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
 		InvoicePayment Create(InvoicePayment invoicePayment);
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
 		InvoicePayment Get(long? id);
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
 		void Delete(long? id);
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
         EntityCollection<InvoicePaymentSubset> Find(InvoicePaymentSearch searchSettings);
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
         void Bookkeep(long? id);
 
 		Task<InvoicePayment> UpdateAsync(InvoicePayment invoicePayment);

--- a/FortnoxSDK/Interfaces/ILabelConnector.cs
+++ b/FortnoxSDK/Interfaces/ILabelConnector.cs
@@ -9,13 +9,13 @@ namespace Fortnox.SDK.Interfaces
     /// <remarks/>
     public interface ILabelConnector : IEntityConnector
 	{
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
 		Label Update(Label label);
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
 		Label Create(Label label);
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
 		void Delete(long? id);
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
 		EntityCollection<Label> Find(LabelSearch searchSettings);
 
 		Task<Label> UpdateAsync(Label label);

--- a/FortnoxSDK/Interfaces/ILockedPeriodConnector.cs
+++ b/FortnoxSDK/Interfaces/ILockedPeriodConnector.cs
@@ -8,7 +8,7 @@ namespace Fortnox.SDK.Interfaces
     /// <remarks/>
     public interface ILockedPeriodConnector : IEntityConnector
 	{
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
         LockedPeriod Get();
 
         Task<LockedPeriod> GetAsync();

--- a/FortnoxSDK/Interfaces/IModeOfPaymentConnector.cs
+++ b/FortnoxSDK/Interfaces/IModeOfPaymentConnector.cs
@@ -9,15 +9,15 @@ namespace Fortnox.SDK.Interfaces
     /// <remarks/>
     public interface IModeOfPaymentConnector : IEntityConnector
 	{
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
 		ModeOfPayment Update(ModeOfPayment modeOfPayment);
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
 		ModeOfPayment Create(ModeOfPayment modeOfPayment);
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
 		ModeOfPayment Get(string id);
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
 		void Delete(string id);
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
 		EntityCollection<ModeOfPayment> Find(ModeOfPaymentSearch searchSettings);
 
 		Task<ModeOfPayment> UpdateAsync(ModeOfPayment modeOfPayment);

--- a/FortnoxSDK/Interfaces/IOfferConnector.cs
+++ b/FortnoxSDK/Interfaces/IOfferConnector.cs
@@ -9,25 +9,25 @@ namespace Fortnox.SDK.Interfaces
     /// <remarks/>
     public interface IOfferConnector : IEntityConnector
 	{
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
 		Offer Update(Offer offer);
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
 		Offer Create(Offer offer);
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
         Offer Get(long? id);
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
         EntityCollection<OfferSubset> Find(OfferSearch searchSettings);
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
         Offer CreateOrder(long? id);
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
         Offer Cancel(long? id);
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
         Offer Email(long? id);
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
         byte[] Print(long? id);
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
         Offer ExternalPrint(long? id);
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
         byte[] Preview(long? id);
 
 		Task<Offer> UpdateAsync(Offer offer);

--- a/FortnoxSDK/Interfaces/IOrderConnector.cs
+++ b/FortnoxSDK/Interfaces/IOrderConnector.cs
@@ -9,25 +9,25 @@ namespace Fortnox.SDK.Interfaces
     /// <remarks/>
     public interface IOrderConnector : IEntityConnector
 	{
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
 		Order Update(Order order);
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
 		Order Create(Order order);
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
 		Order Get(long? id);
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
 		EntityCollection<OrderSubset> Find(OrderSearch searchSettings);
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
 		Order CreateInvoice(long? id);
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
 		Order Cancel(long? id);
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
         Order Email(long? id);
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
         byte[] Print(long? id);
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
         Order ExternalPrint(long? id);
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
         byte[] Preview(long? id);
 
         Task<Order> UpdateAsync(Order order);

--- a/FortnoxSDK/Interfaces/IPredefinedAccountsConnector.cs
+++ b/FortnoxSDK/Interfaces/IPredefinedAccountsConnector.cs
@@ -9,11 +9,11 @@ namespace Fortnox.SDK.Interfaces
     /// <remarks/>
     public interface IPredefinedAccountsConnector : IEntityConnector
 	{
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
 		PredefinedAccount Update(PredefinedAccount predefinedAccounts);
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
 		PredefinedAccount Get(string id);
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
 		EntityCollection<PredefinedAccount> Find(PredefinedAccountsSearch searchSettings);
 
 		Task<PredefinedAccount> UpdateAsync(PredefinedAccount predefinedAccounts);

--- a/FortnoxSDK/Interfaces/IPredefinedVoucherSeriesConnector.cs
+++ b/FortnoxSDK/Interfaces/IPredefinedVoucherSeriesConnector.cs
@@ -9,11 +9,11 @@ namespace Fortnox.SDK.Interfaces
     /// <remarks/>
     public interface IPredefinedVoucherSeriesConnector : IEntityConnector
 	{
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
         PredefinedVoucherSeries Update(PredefinedVoucherSeries predefinedVoucherSeries);
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
         PredefinedVoucherSeries Get(string id);
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
         EntityCollection<PredefinedVoucherSeries> Find(PredefinedVoucherSeriesSearch searchSettings);
 
 		Task<PredefinedVoucherSeries> UpdateAsync(PredefinedVoucherSeries predefinedVoucherSeries);

--- a/FortnoxSDK/Interfaces/IPriceConnector.cs
+++ b/FortnoxSDK/Interfaces/IPriceConnector.cs
@@ -9,15 +9,15 @@ namespace Fortnox.SDK.Interfaces
     /// <remarks/>
     public interface IPriceConnector : IEntityConnector
 	{
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
 		Price Update(Price price);
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
 		Price Create(Price price);
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
 		Price Get(string priceListCode, string articleNumber, decimal? fromQuantity = null);
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
 		void Delete(string priceListCode, string articleNumber, decimal? fromQuantity = null);
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
 		EntityCollection<PriceSubset> Find(string priceListId, string articleId, PriceSearch searchSettings);
 
 		Task<Price> UpdateAsync(Price price);

--- a/FortnoxSDK/Interfaces/IPriceListConnector.cs
+++ b/FortnoxSDK/Interfaces/IPriceListConnector.cs
@@ -9,13 +9,13 @@ namespace Fortnox.SDK.Interfaces
     /// <remarks/>
     public interface IPriceListConnector : IEntityConnector
 	{
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
 		PriceList Update(PriceList priceList);
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
 		PriceList Create(PriceList priceList);
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
 		PriceList Get(string id);
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
 		EntityCollection<PriceList> Find(PriceListSearch searchSettings);
 
 		Task<PriceList> UpdateAsync(PriceList priceList);

--- a/FortnoxSDK/Interfaces/IPrintTemplateConnector.cs
+++ b/FortnoxSDK/Interfaces/IPrintTemplateConnector.cs
@@ -9,7 +9,7 @@ namespace Fortnox.SDK.Interfaces
     /// <remarks/>
     public interface IPrintTemplateConnector : IEntityConnector
 	{
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
 		EntityCollection<PrintTemplate> Find(PrintTemplateSearch searchSettings);
 
 		Task<EntityCollection<PrintTemplate>> FindAsync(PrintTemplateSearch searchSettings);

--- a/FortnoxSDK/Interfaces/IProjectConnector.cs
+++ b/FortnoxSDK/Interfaces/IProjectConnector.cs
@@ -9,15 +9,15 @@ namespace Fortnox.SDK.Interfaces
     /// <remarks/>
     public interface IProjectConnector : IEntityConnector
 	{
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
 		Project Update(Project project);
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
 		Project Create(Project project);
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
 		Project Get(string id);
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
 		void Delete(string id);
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
 		EntityCollection<ProjectSubset> Find(ProjectSearch searchSettings);
 
 		Task<Project> UpdateAsync(Project project);

--- a/FortnoxSDK/Interfaces/ISIEConnector.cs
+++ b/FortnoxSDK/Interfaces/ISIEConnector.cs
@@ -7,7 +7,7 @@ namespace Fortnox.SDK.Interfaces
 {
     public interface ISIEConnector : IConnector
     {
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
         byte[] Get(SIEType type, long? finYearID = null, SIEExportOptions exportOptions = null);
 
         Task<byte[]> GetAsync(SIEType type, long? finYearID = null, SIEExportOptions exportOptions = null);

--- a/FortnoxSDK/Interfaces/ISalaryTransactionConnector.cs
+++ b/FortnoxSDK/Interfaces/ISalaryTransactionConnector.cs
@@ -9,15 +9,15 @@ namespace Fortnox.SDK.Interfaces
     /// <remarks/>
     public interface ISalaryTransactionConnector : IEntityConnector
 	{
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
 		SalaryTransaction Update(SalaryTransaction salaryTransaction);
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
 		SalaryTransaction Create(SalaryTransaction salaryTransaction);
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
 		SalaryTransaction Get(long? id);
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
 		void Delete(long? id);
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
 		EntityCollection<SalaryTransactionSubset> Find(SalaryTransactionSearch searchSettings);
 
 		Task<SalaryTransaction> UpdateAsync(SalaryTransaction salaryTransaction);

--- a/FortnoxSDK/Interfaces/IScheduleTimesConnector.cs
+++ b/FortnoxSDK/Interfaces/IScheduleTimesConnector.cs
@@ -8,11 +8,11 @@ namespace Fortnox.SDK.Interfaces
     /// <remarks/>
     public interface IScheduleTimesConnector : IEntityConnector
 	{
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
         ScheduleTimes Update(ScheduleTimes scheduleTimes);
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
         ScheduleTimes Get(string employeeId, DateTime? date);
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
         ScheduleTimes Reset(string employeeId, DateTime? date);
 
 		Task<ScheduleTimes> UpdateAsync(ScheduleTimes scheduleTimes);

--- a/FortnoxSDK/Interfaces/ISupplierConnector.cs
+++ b/FortnoxSDK/Interfaces/ISupplierConnector.cs
@@ -9,15 +9,15 @@ namespace Fortnox.SDK.Interfaces
     /// <remarks/>
     public interface ISupplierConnector : IEntityConnector
 	{
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
 		Supplier Update(Supplier supplier);
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
 		Supplier Create(Supplier supplier);
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
 		Supplier Get(string id);
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
 		void Delete(string id);
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
 		EntityCollection<SupplierSubset> Find(SupplierSearch searchSettings);
 
 		Task<Supplier> UpdateAsync(Supplier supplier);

--- a/FortnoxSDK/Interfaces/ISupplierInvoiceAccrualConnector.cs
+++ b/FortnoxSDK/Interfaces/ISupplierInvoiceAccrualConnector.cs
@@ -9,15 +9,15 @@ namespace Fortnox.SDK.Interfaces
     /// <remarks/>
     public interface ISupplierInvoiceAccrualConnector : IEntityConnector
 	{
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
 		SupplierInvoiceAccrual Update(SupplierInvoiceAccrual supplierInvoiceAccrual);
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
 		SupplierInvoiceAccrual Create(SupplierInvoiceAccrual supplierInvoiceAccrual);
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
 		SupplierInvoiceAccrual Get(long? id);
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
 		void Delete(long? id);
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
 		EntityCollection<SupplierInvoiceAccrualSubset> Find(SupplierInvoiceAccrualSearch searchSettings);
 
 		Task<SupplierInvoiceAccrual> UpdateAsync(SupplierInvoiceAccrual supplierInvoiceAccrual);

--- a/FortnoxSDK/Interfaces/ISupplierInvoiceConnector.cs
+++ b/FortnoxSDK/Interfaces/ISupplierInvoiceConnector.cs
@@ -9,23 +9,23 @@ namespace Fortnox.SDK.Interfaces
     /// <remarks/>
     public interface ISupplierInvoiceConnector : IEntityConnector
 	{
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
 		SupplierInvoice Update(SupplierInvoice supplierInvoice);
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
 		SupplierInvoice Create(SupplierInvoice supplierInvoice);
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
 		SupplierInvoice Get(long? id);
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
 		EntityCollection<SupplierInvoiceSubset> Find(SupplierInvoiceSearch searchSettings);
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
 		SupplierInvoice Bookkeep(long? id);
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
 		SupplierInvoice Cancel(long? id);
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
         SupplierInvoice Credit(long? id);
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
         SupplierInvoice ApprovalPayment(long? id);
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
         SupplierInvoice ApprovalBookkeep(long? id);
 
 		Task<SupplierInvoice> UpdateAsync(SupplierInvoice supplierInvoice);

--- a/FortnoxSDK/Interfaces/ISupplierInvoiceExternalURLConnectionConnector.cs
+++ b/FortnoxSDK/Interfaces/ISupplierInvoiceExternalURLConnectionConnector.cs
@@ -9,15 +9,15 @@ namespace Fortnox.SDK.Interfaces
     /// <remarks/>
     public interface ISupplierInvoiceExternalURLConnectionConnector : IEntityConnector
 	{
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
 		SupplierInvoiceExternalURLConnection Update(SupplierInvoiceExternalURLConnection supplierInvoiceExternalURLConnection);
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
 		SupplierInvoiceExternalURLConnection Create(SupplierInvoiceExternalURLConnection supplierInvoiceExternalURLConnection);
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
 		SupplierInvoiceExternalURLConnection Get(long? id);
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
 		void Delete(long? id);
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
 		EntityCollection<SupplierInvoiceExternalURLConnection> Find(SupplierInvoiceExternalURLConnectionSearch searchSettings);
 
 		Task<SupplierInvoiceExternalURLConnection> UpdateAsync(SupplierInvoiceExternalURLConnection supplierInvoiceExternalURLConnection);

--- a/FortnoxSDK/Interfaces/ISupplierInvoiceFileConnectionConnector.cs
+++ b/FortnoxSDK/Interfaces/ISupplierInvoiceFileConnectionConnector.cs
@@ -9,13 +9,13 @@ namespace Fortnox.SDK.Interfaces
     /// <remarks/>
     public interface ISupplierInvoiceFileConnectionConnector : IEntityConnector
 	{
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
 		SupplierInvoiceFileConnection Create(SupplierInvoiceFileConnection supplierInvoiceFileConnection);
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
 		SupplierInvoiceFileConnection Get(string id);
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
 		void Delete(string id);
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
 		EntityCollection<SupplierInvoiceFileConnection> Find(SupplierInvoiceFileConnectionSearch searchSettings);
 
         Task<SupplierInvoiceFileConnection> CreateAsync(SupplierInvoiceFileConnection supplierInvoiceFileConnection);

--- a/FortnoxSDK/Interfaces/ISupplierInvoicePaymentConnector.cs
+++ b/FortnoxSDK/Interfaces/ISupplierInvoicePaymentConnector.cs
@@ -9,17 +9,17 @@ namespace Fortnox.SDK.Interfaces
     /// <remarks/>
     public interface ISupplierInvoicePaymentConnector : IEntityConnector
 	{
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
 		SupplierInvoicePayment Update(SupplierInvoicePayment supplierInvoicePayment);
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
 		SupplierInvoicePayment Create(SupplierInvoicePayment supplierInvoicePayment);
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
 		SupplierInvoicePayment Get(long? id);
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
 		void Delete(long? id);
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
 		EntityCollection<SupplierInvoicePaymentSubset> Find(SupplierInvoicePaymentSearch searchSettings);
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
 		public void Bookkeep(long? id);
 
         Task<SupplierInvoicePayment> UpdateAsync(SupplierInvoicePayment supplierInvoicePayment);

--- a/FortnoxSDK/Interfaces/ITaxReductionConnector.cs
+++ b/FortnoxSDK/Interfaces/ITaxReductionConnector.cs
@@ -9,15 +9,15 @@ namespace Fortnox.SDK.Interfaces
     /// <remarks/>
     public interface ITaxReductionConnector : IEntityConnector
 	{
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
 		TaxReduction Update(TaxReduction taxReduction);
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
 		TaxReduction Create(TaxReduction taxReduction);
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
 		TaxReduction Get(string id);
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
 		void Delete(string id);
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
 		EntityCollection<TaxReductionSubset> Find(TaxReductionSearch searchSettings);
 
 		Task<TaxReduction> UpdateAsync(TaxReduction taxReduction);

--- a/FortnoxSDK/Interfaces/ITermsOfDeliveryConnector.cs
+++ b/FortnoxSDK/Interfaces/ITermsOfDeliveryConnector.cs
@@ -9,15 +9,15 @@ namespace Fortnox.SDK.Interfaces
     /// <remarks/>
     public interface ITermsOfDeliveryConnector : IEntityConnector
 	{
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
 		TermsOfDelivery Update(TermsOfDelivery termsOfDelivery);
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
 		TermsOfDelivery Create(TermsOfDelivery termsOfDelivery);
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
 		TermsOfDelivery Get(string id);
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
 		void Delete(string id);
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
 		EntityCollection<TermsOfDelivery> Find(TermsOfDeliverySearch searchSettings);
 
 		Task<TermsOfDelivery> UpdateAsync(TermsOfDelivery termsOfDelivery);

--- a/FortnoxSDK/Interfaces/ITermsOfPaymentConnector.cs
+++ b/FortnoxSDK/Interfaces/ITermsOfPaymentConnector.cs
@@ -9,15 +9,15 @@ namespace Fortnox.SDK.Interfaces
     /// <remarks/>
     public interface ITermsOfPaymentConnector : IEntityConnector
 	{
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
 		TermsOfPayment Update(TermsOfPayment termsOfPayment);
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
 		TermsOfPayment Create(TermsOfPayment termsOfPayment);
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
 		TermsOfPayment Get(string id);
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
 		void Delete(string id);
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
 		EntityCollection<TermsOfPayment> Find(TermsOfPaymentSearch searchSettings);
 
 		Task<TermsOfPayment> UpdateAsync(TermsOfPayment termsOfPayment);

--- a/FortnoxSDK/Interfaces/ITrustedEmailDomainsConnector.cs
+++ b/FortnoxSDK/Interfaces/ITrustedEmailDomainsConnector.cs
@@ -9,13 +9,13 @@ namespace Fortnox.SDK.Interfaces
     /// <remarks/>
     public interface ITrustedEmailDomainsConnector : IEntityConnector
 	{
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
 		TrustedEmailDomain Create(TrustedEmailDomain trustedEmailDomain);
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
 		TrustedEmailDomain Get(long? id);
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
 		void Delete(long? id);
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
 		EntityCollection<TrustedEmailDomain> Find(TrustedEmailDomainsSearch searchSettings);
 
         Task<TrustedEmailDomain> CreateAsync(TrustedEmailDomain trustedEmailDomain);

--- a/FortnoxSDK/Interfaces/ITrustedEmailSendersConnector.cs
+++ b/FortnoxSDK/Interfaces/ITrustedEmailSendersConnector.cs
@@ -8,11 +8,11 @@ namespace Fortnox.SDK.Interfaces
     /// <remarks/>
     public interface ITrustedEmailSendersConnector : IEntityConnector
 	{
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
         TrustedEmailSender Create(TrustedEmailSender trustedEmailSenders);
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
         void Delete(long? id);
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
         EmailSenders GetAll();
 
         Task<TrustedEmailSender> CreateAsync(TrustedEmailSender trustedEmailSenders);

--- a/FortnoxSDK/Interfaces/IUnitConnector.cs
+++ b/FortnoxSDK/Interfaces/IUnitConnector.cs
@@ -9,15 +9,15 @@ namespace Fortnox.SDK.Interfaces
     /// <remarks/>
     public interface IUnitConnector : IEntityConnector
 	{
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
 		Unit Update(Unit unit);
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
 		Unit Create(Unit unit);
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
 		Unit Get(string id);
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
 		void Delete(string id);
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
 		EntityCollection<Unit> Find(UnitSearch searchSettings);
 
 		Task<Unit> UpdateAsync(Unit unit);

--- a/FortnoxSDK/Interfaces/IVoucherConnector.cs
+++ b/FortnoxSDK/Interfaces/IVoucherConnector.cs
@@ -9,13 +9,13 @@ namespace Fortnox.SDK.Interfaces
     /// <remarks/>
     public interface IVoucherConnector : IEntityConnector
 	{
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
         Voucher Create(Voucher voucher);
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
         Voucher Get(long? id, string seriesId, long? financialYearId);
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
         EntityCollection<VoucherSubset> Find(VoucherSearch searchSettings);
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
         void Delete(long? id, string seriesId, long? financialYearId);
 
         Task<Voucher> CreateAsync(Voucher voucher);

--- a/FortnoxSDK/Interfaces/IVoucherFileConnectionConnector.cs
+++ b/FortnoxSDK/Interfaces/IVoucherFileConnectionConnector.cs
@@ -9,13 +9,13 @@ namespace Fortnox.SDK.Interfaces
     /// <remarks/>
     public interface IVoucherFileConnectionConnector : IEntityConnector
 	{
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
 		VoucherFileConnection Create(VoucherFileConnection voucherFileConnection, long? financialYearId = null);
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
 		VoucherFileConnection Get(string id);
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
 		void Delete(string id);
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
 		EntityCollection<VoucherFileConnection> Find(VoucherFileConnectionSearch searchSettings);
 
         Task<VoucherFileConnection> CreateAsync(VoucherFileConnection voucherFileConnection, long? financialYearId = null);

--- a/FortnoxSDK/Interfaces/IVoucherSeriesConnector.cs
+++ b/FortnoxSDK/Interfaces/IVoucherSeriesConnector.cs
@@ -9,13 +9,13 @@ namespace Fortnox.SDK.Interfaces
     /// <remarks/>
     public interface IVoucherSeriesConnector : IEntityConnector
 	{
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
 		VoucherSeries Update(VoucherSeries voucherSeries, long? financialYearId = null);
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
 		VoucherSeries Create(VoucherSeries voucherSeries, long? financialYearId = null);
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
 		VoucherSeries Get(string id, long? financialYearId = null);
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
 		EntityCollection<VoucherSeriesSubset> Find(VoucherSeriesSearch searchSettings);
 
 		Task<VoucherSeries> UpdateAsync(VoucherSeries voucherSeries, long? financialYearId = null);

--- a/FortnoxSDK/Interfaces/IWayOfDeliveryConnector.cs
+++ b/FortnoxSDK/Interfaces/IWayOfDeliveryConnector.cs
@@ -9,15 +9,15 @@ namespace Fortnox.SDK.Interfaces
     /// <remarks/>
     public interface IWayOfDeliveryConnector : IEntityConnector
 	{
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
 		WayOfDelivery Update(WayOfDelivery wayOfDelivery);
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
 		WayOfDelivery Create(WayOfDelivery wayOfDelivery);
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
 		WayOfDelivery Get(string id);
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
 		void Delete(string id);
-        [Obsolete(APIConstants.ObsoleteSyncMethodWarning)]
+        [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
 		EntityCollection<WayOfDelivery> Find(WayOfDeliverySearch searchSettings);
 
 		Task<WayOfDelivery> UpdateAsync(WayOfDelivery wayOfDelivery);

--- a/FortnoxSDK/Requests/BaseRequest.cs
+++ b/FortnoxSDK/Requests/BaseRequest.cs
@@ -11,7 +11,7 @@ namespace Fortnox.SDK.Requests
         public IDictionary<string, string> Headers { get; set; } = new Dictionary<string, string>();
         public byte[] Content { get; set; }
 
-        public string BaseUrl { get; set; } = APIConstants.FortnoxApi;
+        public string BaseUrl { get; set; } = ApiConstants.FortnoxApi;
         public string Version { get; set; } = "3";
         public string Resource { get; set; }
         public IList<string> Indices { get; set; } = new List<string>();

--- a/FortnoxSDK/Utility/Utils.cs
+++ b/FortnoxSDK/Utility/Utils.cs
@@ -17,9 +17,9 @@ namespace Fortnox.SDK.Utility
             if (type == typeof(DateTime))
             {
                 if (((DateTime)value).Date == (DateTime)value) //Date without hours/minutes/seconds..
-                    return ((DateTime)value).ToString(APIConstants.DateFormat);
+                    return ((DateTime)value).ToString(ApiConstants.DateFormat);
 
-                return ((DateTime)value).ToString(APIConstants.DateAndTimeFormat);
+                return ((DateTime)value).ToString(ApiConstants.DateAndTimeFormat);
             }
 
             return value.ToString().ToLower();


### PR DESCRIPTION
The rename adheres to the Microsoft naming guidelines.
https://docs.microsoft.com/en-us/dotnet/standard/design-guidelines/capitalization-conventions