### PR TITLE
Change token expiration in documentation

### DIFF
--- a/FortnoxSDK/Auth/IAuthWorkflow.cs
+++ b/FortnoxSDK/Auth/IAuthWorkflow.cs
@@ -21,7 +21,8 @@ public interface IStandardAuthWorkflow
     /// <exception cref="FortnoxApiException">If the Fortnox API returns an error.</exception>
     /// <remarks>
     /// <para>The authorization code is valid for 10 minutes. It can only be used once.</para>
-    /// <para>The token is valid for 10 minutes. It can be re-used several times.</para>
+    /// <para>The access token is valid for 1 hour. It can be re-used several times.</para>
+    /// <para>The refresh token is valid for 1 month (31 days). It can only be used once.</para>
     /// </remarks>
     [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
     TokenInfo GetToken(string authCode, string clientId, string clientSecret, string redirectUri = null);
@@ -37,7 +38,8 @@ public interface IStandardAuthWorkflow
     /// <exception cref="FortnoxApiException">If the Fortnox API returns an error.</exception>
     /// <remarks>
     /// <para>The authorization code is valid for 10 minutes. It can only be used once.</para>
-    /// <para>The token is valid for 10 minutes. It can be re-used several times.</para>
+    /// <para>The access token is valid for 1 hour. It can be re-used several times.</para>
+    /// <para>The refresh token is valid for 1 month (31 days). It can only be used once.</para>
     /// </remarks>
     Task<TokenInfo> GetTokenAsync(string authCode, string clientId, string clientSecret, string redirectUri = null);
 
@@ -49,7 +51,7 @@ public interface IStandardAuthWorkflow
     /// <param name="clientId">Client id given to you by Fortnox.</param>
     /// <param name="clientSecret">Client secret given to you by Fortnox.</param>
     /// <returns>OAuth 2 token information.</returns>
-    /// <remarks>The refresh token is valid for 30 days. It can only be used once.</remarks>
+    /// <remarks>The refresh token is valid for 1 month (31 days). It can only be used once.</remarks>
     [Obsolete(ApiConstants.ObsoleteSyncMethodWarning)]
     TokenInfo RefreshToken(string refreshToken, string clientId, string clientSecret);
 
@@ -61,7 +63,7 @@ public interface IStandardAuthWorkflow
     /// <param name="clientId">Client id given to you by Fortnox.</param>
     /// <param name="clientSecret">Client secret given to you by Fortnox.</param>
     /// <returns>OAuth 2 token information.</returns>
-    /// <remarks>The refresh token is valid for 30 days. It can only be used once.</remarks>
+    /// <remarks>The refresh token is valid for 1 month (31 days). It can only be used once.</remarks>
     Task<TokenInfo> RefreshTokenAsync(string refreshToken, string clientId, string clientSecret);
 
     /// <summary>


### PR DESCRIPTION
Changed from 10 minutes to 1 hour.

> Access-Token - Token with limited lifetime used by your application when making API requests on behalf of a user. Expiration time: 1 hour

Source: https://developer.fortnox.se/general/authentication/