### PR TITLE
Add part of warehouse features

### DIFF
--- a/FortnoxSDK.Tests/ConnectorTests/AccountChartTests.cs
+++ b/FortnoxSDK.Tests/ConnectorTests/AccountChartTests.cs
@@ -23,7 +23,7 @@ public class AccountChartTests
 
         var fullCollection = await connector.FindAsync(null);
 
-        Assert.AreEqual(6, fullCollection.Entities.Count);
+        Assert.AreEqual(8, fullCollection.Entities.Count);
         Assert.IsNotNull(fullCollection.Entities.First().Name);
 
         //Limit not supported

--- a/FortnoxSDK.Tests/WarehouseTests.cs
+++ b/FortnoxSDK.Tests/WarehouseTests.cs
@@ -86,6 +86,7 @@ public class WarehouseTests
         #endregion Delete arranged resources
     }
 
+    [TestMethod]
     public async Task Test_Order_DeliveryState_Update()
     {
         #region Arrange
@@ -113,7 +114,7 @@ public class WarehouseTests
         order.DeliveryState = DeliveryState.Delivery;
 
         order = await FortnoxClient.OrderConnector.UpdateAsync(order);
-        Assert.AreEqual(DeliveryState.Delivery, order.WarehouseReady);
+        Assert.AreEqual(DeliveryState.Delivery, order.DeliveryState);
 
         #region Delete arranged resources
         await FortnoxClient.OrderConnector.CancelAsync(order.DocumentNumber);

--- a/FortnoxSDK.Tests/WarehouseTests.cs
+++ b/FortnoxSDK.Tests/WarehouseTests.cs
@@ -121,4 +121,22 @@ public class WarehouseTests
         //client.ArticleConnector.Delete(tmpArticle.ArticleNumber);
         #endregion Delete arranged resources
     }
+
+    [TestMethod]
+    public async Task Test_Tenant_WarehouseActivated_Get()
+    {
+        var tenant = await FortnoxClient.TenantConnector.GetAsync();
+
+        Assert.AreEqual(true, tenant.WarehouseActivated);
+        Assert.AreEqual(1212851, tenant.TenantId);
+    }
+
+    [TestMethod]
+    public async Task Test_Tenant_WarehouseDisabled_Get()
+    {
+        var tenant = await TestUtils.DefaultFortnoxClient.TenantConnector.GetAsync();
+
+        Assert.AreEqual(false, tenant.WarehouseActivated);
+        Assert.AreEqual(1018318, tenant.TenantId);
+    }
 }

--- a/FortnoxSDK.Tests/WarehouseTests.cs
+++ b/FortnoxSDK.Tests/WarehouseTests.cs
@@ -1,0 +1,88 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Fortnox.SDK;
+using Fortnox.SDK.Authorization;
+using Fortnox.SDK.Entities;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace FortnoxSDK.Tests;
+
+[TestClass]
+public class WarehouseTests
+{
+    public FortnoxClient FortnoxClient = new FortnoxClient(new StaticTokenAuth("006738d2-3698-44af-b6d2-3103f3bf5b89", TestCredentials.Client_Secret));
+
+    [TestMethod]
+    public async Task Test_Order_WarehouseReady()
+    {
+        #region Arrange
+        var tmpCustomer = await FortnoxClient.CustomerConnector.CreateAsync(new Customer() { Name = "TmpCustomer", CountryCode = "SE", City = "Testopolis", Email = "richard.randak@softwerk.se" });
+        var tmpArticle = await FortnoxClient.ArticleConnector.CreateAsync(new Article() { Description = "TmpArticle", Type = ArticleType.Stock, PurchasePrice = 100 });
+        #endregion Arrange
+
+        var order = new Order()
+        {
+            Comments = "TestOrder",
+            CustomerNumber = tmpCustomer.CustomerNumber,
+            OrderDate = new DateTime(2019, 1, 20), //"2019-01-20",
+            OrderRows = new List<OrderRow>()
+            {
+                new OrderRow(){ ArticleNumber = tmpArticle.ArticleNumber, OrderedQuantity = 20, DeliveredQuantity = 10},
+                new OrderRow(){ ArticleNumber = tmpArticle.ArticleNumber, OrderedQuantity = 20, DeliveredQuantity = 20},
+                new OrderRow(){ ArticleNumber = tmpArticle.ArticleNumber, OrderedQuantity = 20, DeliveredQuantity = 15}
+            }
+        };
+
+        order.DeliveryState = DeliveryState.Delivery;
+
+        order = await FortnoxClient.OrderConnector.CreateAsync(order);
+        Assert.AreEqual(false, order.WarehouseReady);
+
+        order = await FortnoxClient.OrderConnector.WarehouseReady(order.DocumentNumber);
+        Assert.AreEqual(true, order.WarehouseReady);
+
+        #region Delete arranged resources
+        await FortnoxClient.OrderConnector.CancelAsync(order.DocumentNumber);
+        await FortnoxClient.CustomerConnector.DeleteAsync(tmpCustomer.CustomerNumber);
+        //client.ArticleConnector.Delete(tmpArticle.ArticleNumber);
+        #endregion Delete arranged resources
+    }
+
+    [TestMethod]
+    public async Task Test_Invoice_WarehouseReady()
+    {
+        #region Arrange
+        var tmpCustomer = await FortnoxClient.CustomerConnector.CreateAsync(new Customer() { Name = "TmpCustomer", CountryCode = "SE", City = "Testopolis" });
+        var tmpArticle = await FortnoxClient.ArticleConnector.CreateAsync(new Article() { Description = "TmpArticle", Type = ArticleType.Stock, PurchasePrice = 100 });
+        #endregion Arrange
+
+        var invoice = new Invoice()
+        {
+            CustomerNumber = tmpCustomer.CustomerNumber,
+            InvoiceDate = new DateTime(2019, 1, 20), //"2019-01-20",
+            DueDate = new DateTime(2019, 2, 20), //"2019-02-20",
+            InvoiceType = InvoiceType.CashInvoice,
+            PaymentWay = PaymentWay.Cash,
+            Comments = "TestInvoice",
+            InvoiceRows = new List<InvoiceRow>()
+            {
+                new InvoiceRow(){ ArticleNumber = tmpArticle.ArticleNumber, DeliveredQuantity = 10, Price = 100},
+                new InvoiceRow(){ ArticleNumber = tmpArticle.ArticleNumber, DeliveredQuantity = 20, Price = 100},
+                new InvoiceRow(){ ArticleNumber = tmpArticle.ArticleNumber, DeliveredQuantity = 15, Price = 100}
+            }
+        };
+
+        invoice = await FortnoxClient.InvoiceConnector.CreateAsync(invoice);
+        Assert.AreEqual(false, invoice.WarehouseReady);
+
+        invoice = await FortnoxClient.InvoiceConnector.WarehouseReady(invoice.DocumentNumber);
+        Assert.AreEqual(true, invoice.WarehouseReady);
+
+        #region Delete arranged resources
+        await FortnoxClient.InvoiceConnector.CancelAsync(invoice.DocumentNumber);
+        await FortnoxClient.CustomerConnector.DeleteAsync(tmpCustomer.CustomerNumber);
+        //client.ArticleConnector.Delete(tmpArticle.ArticleNumber);
+        #endregion Delete arranged resources
+    }
+}

--- a/FortnoxSDK/Action.cs
+++ b/FortnoxSDK/Action.cs
@@ -51,7 +51,10 @@ public enum Action
     EInvoice,
 
     [EnumMember(Value = "createorder")]
-    CreateOrder
+    CreateOrder,
+
+    [EnumMember(Value = "warehouseready")]
+    WarehouseReady
 }
 
 public static class ActionExtensions

--- a/FortnoxSDK/Connectors/AssetConnector.cs
+++ b/FortnoxSDK/Connectors/AssetConnector.cs
@@ -10,10 +10,11 @@ namespace Fortnox.SDK.Connectors;
 
 internal class AssetConnector : SearchableEntityConnector<Asset, AssetSubset, AssetSearch>, IAssetConnector
 {
+    protected override ISerializer Serializer => new AssetSerializer();
+
     public AssetConnector()
     {
         Endpoint = Endpoints.Assets;
-        Serializer = new AssetSerializer();
     }
 
     public async Task<EntityCollection<AssetSubset>> FindAsync(AssetSearch searchSettings)

--- a/FortnoxSDK/Connectors/AssetTypesConnector.cs
+++ b/FortnoxSDK/Connectors/AssetTypesConnector.cs
@@ -11,10 +11,11 @@ namespace Fortnox.SDK.Connectors;
 
 internal class AssetTypesConnector : SearchableEntityConnector<AssetType, AssetTypesSubset, AssetTypesSearch>, IAssetTypesConnector
 {
+    protected override ISerializer Serializer => new AssetTypeSerializer();
+
     public AssetTypesConnector()
     {
         Endpoint = Endpoints.AssetTypes;
-        Serializer = new AssetTypeSerializer();
     }
 
     public async Task<EntityCollection<AssetTypesSubset>> FindAsync(AssetTypesSearch searchSettings)

--- a/FortnoxSDK/Connectors/Base/BaseConnector.cs
+++ b/FortnoxSDK/Connectors/Base/BaseConnector.cs
@@ -10,13 +10,10 @@ namespace Fortnox.SDK.Connectors.Base;
 
 internal abstract class BaseConnector : BaseClient
 {
-    protected ISerializer Serializer { get; set; }
-    protected string Endpoint { get; set; }
+    public bool WarehouseEnabled { get; set; }
+    protected virtual ISerializer Serializer => new JsonEntitySerializer(WarehouseEnabled);
 
-    protected BaseConnector()
-    {
-        Serializer = new JsonEntitySerializer();
-    }
+    protected string Endpoint { get; set; }
 
     protected async Task<byte[]> SendAsync(BaseRequest fortnoxRequest)
     {

--- a/FortnoxSDK/Connectors/InvoiceConnector.cs
+++ b/FortnoxSDK/Connectors/InvoiceConnector.cs
@@ -77,4 +77,9 @@ internal class InvoiceConnector : SearchableEntityConnector<Invoice, InvoiceSubs
     {
         return await DoDownloadActionAsync(id.ToString(), Action.Preview).ConfigureAwait(false);
     }
+
+    public async Task<Invoice> WarehouseReady(long? id)
+    {
+        return await DoActionAsync(id.ToString(), Action.WarehouseReady).ConfigureAwait(false);
+    }
 }

--- a/FortnoxSDK/Connectors/OrderConnector.cs
+++ b/FortnoxSDK/Connectors/OrderConnector.cs
@@ -62,4 +62,9 @@ internal class OrderConnector : SearchableEntityConnector<Order, OrderSubset, Or
     {
         return await DoDownloadActionAsync(id.ToString(), Action.Preview).ConfigureAwait(false);
     }
+
+    public async Task<Order> WarehouseReady(long? id)
+    {
+        return await DoActionAsync(id.ToString(), Action.WarehouseReady).ConfigureAwait(false);
+    }
 }

--- a/FortnoxSDK/Connectors/TenantConnector.cs
+++ b/FortnoxSDK/Connectors/TenantConnector.cs
@@ -1,0 +1,28 @@
+﻿using System.Net.Http;
+using System.Threading.Tasks;
+using Fortnox.SDK.Connectors.Base;
+using Fortnox.SDK.Entities.Tenants;
+using Fortnox.SDK.Interfaces;
+using Fortnox.SDK.Requests;
+
+namespace Fortnox.SDK.Connectors;
+
+internal class TenantConnector : EntityConnector<Tenant>, ITenantConnector
+{
+    public TenantConnector()
+    {
+        Endpoint = Endpoints.Tenant;
+    }
+
+    public async Task<Tenant> GetAsync()
+    {
+        var request = new EntityRequest<Tenant>
+        {
+            Endpoint = Endpoint,
+            Method = HttpMethod.Get,
+            UseEntityWrapper = false
+        };
+
+        return await SendAsync(request).ConfigureAwait(false);
+    }
+}

--- a/FortnoxSDK/Endpoints.cs
+++ b/FortnoxSDK/Endpoints.cs
@@ -75,4 +75,6 @@ internal static class Endpoints
     public const string EmailSenders = $"/{Version}/emailsenders";
 
     public const string Profile = $"/{Version}/me";
+
+    public const string Tenant = "/api/warehouse/tenants-v4";
 }

--- a/FortnoxSDK/Entities/Invoices/Invoice.cs
+++ b/FortnoxSDK/Entities/Invoices/Invoice.cs
@@ -381,4 +381,12 @@ public class Invoice
     ///<summary> Zip code of the invoice. </summary>
     [JsonProperty]
     public string ZipCode { get; set; }
+
+    /// <summary> Used to see if the document has been marked as ready in warehouse. </summary>
+    [JsonProperty]
+    public bool? WarehouseReady { get; set; }
+
+    /// <summary> The date that the document was marked as ready in warehouse. </summary>
+    [JsonProperty]
+    public DateTime? OutboundDate { get; set; }
 }

--- a/FortnoxSDK/Entities/Invoices/InvoiceRow.cs
+++ b/FortnoxSDK/Entities/Invoices/InvoiceRow.cs
@@ -92,4 +92,8 @@ public class InvoiceRow
     /// <remarks> See https://developer.fortnox.se/blog/updating-document-rows-using-rowid/ </remarks>
     [JsonProperty]
     public long? RowId { get; set; }
+
+    /// <summary> The stock point that the items are to taken from or has been taken from. </summary>
+    [JsonProperty]
+    public string StockPointCode { get; set; }
 }

--- a/FortnoxSDK/Entities/Orders/DeliveryState.cs
+++ b/FortnoxSDK/Entities/Orders/DeliveryState.cs
@@ -1,0 +1,13 @@
+﻿using System.Runtime.Serialization;
+
+namespace Fortnox.SDK.Entities;
+
+public enum DeliveryState
+{
+    [EnumMember(Value = "delivery")]
+    Delivery,
+    [EnumMember(Value = "registration")]
+    Registration,
+    [EnumMember(Value = "reservation")]
+    Reservation
+}

--- a/FortnoxSDK/Entities/Orders/Order.cs
+++ b/FortnoxSDK/Entities/Orders/Order.cs
@@ -275,4 +275,24 @@ public class Order
     ///<summary> Order zip code </summary>
     [JsonProperty]
     public string ZipCode { get; set; }
+
+    /// <summary> The stock point that the items are to taken from or has been taken from. </summary>
+    [JsonProperty]
+    public string StockPointCode { get; set; }
+
+    /// <summary> The stock point that the items are to taken from or has been taken from. </summary>
+    [JsonProperty]
+    public string StockPointId { get; set; }
+
+    /// <summary> Used to see if the document has been marked as ready in warehouse. </summary>
+    [ReadOnly]
+    [JsonProperty]
+    public bool? WarehouseReady { get; set; }
+
+    /// <summary> The date that the document was marked as ready in warehouse. </summary>
+    [JsonProperty]
+    public DateTime? OutboundDate { get; set; }
+
+    [JsonProperty]
+    public DeliveryState? DeliveryState { get; set; }
 }

--- a/FortnoxSDK/Entities/Orders/Order.cs
+++ b/FortnoxSDK/Entities/Orders/Order.cs
@@ -293,6 +293,7 @@ public class Order
     [JsonProperty]
     public DateTime? OutboundDate { get; set; }
 
+    [WarehouseRequired]
     [JsonProperty]
     public DeliveryState? DeliveryState { get; set; }
 }

--- a/FortnoxSDK/Entities/Orders/Order.cs
+++ b/FortnoxSDK/Entities/Orders/Order.cs
@@ -287,7 +287,7 @@ public class Order
     /// <summary> Used to see if the document has been marked as ready in warehouse. </summary>
     [ReadOnly]
     [JsonProperty]
-    public bool? WarehouseReady { get; set; }
+    public bool? WarehouseReady { get; private set; }
 
     /// <summary> The date that the document was marked as ready in warehouse. </summary>
     [JsonProperty]

--- a/FortnoxSDK/Entities/Orders/OrderRow.cs
+++ b/FortnoxSDK/Entities/Orders/OrderRow.cs
@@ -86,4 +86,18 @@ public class OrderRow
     /// <remarks> See https://developer.fortnox.se/blog/updating-document-rows-using-rowid/ </remarks>
     [JsonProperty]
     public long? RowId { get; set; }
+
+
+    /// <summary> The stock point that the items are to taken from or has been taken from. </summary>
+    [JsonProperty]
+    public string StockPointCode { get; set; }
+
+    /// <summary> The stock point that the items are to taken from or has been taken from. </summary>
+    [JsonProperty]
+    public string StockPointId { get; set; }
+
+    ///<summary> Ordered quantity </summary>
+    ///<remarks>Can only be modified when the document is in the delivery state. (Invoices are always in the delivery state</remarks>
+    [JsonProperty]
+    public decimal? ReservedQuantity { get; set; }
 }

--- a/FortnoxSDK/Entities/Tenants/Tenant.cs
+++ b/FortnoxSDK/Entities/Tenants/Tenant.cs
@@ -1,0 +1,12 @@
+﻿using Newtonsoft.Json;
+
+namespace Fortnox.SDK.Entities.Tenants;
+
+public class Tenant
+{
+    [JsonProperty("tenantId")]
+    public long TenantId { get; set; }
+
+    [JsonProperty("activated")]
+    public bool WarehouseActivated { get; set; }
+}

--- a/FortnoxSDK/FortnoxClient.cs
+++ b/FortnoxSDK/FortnoxClient.cs
@@ -3,7 +3,6 @@ using System.Net.Http;
 using Fortnox.SDK.Authorization;
 using Fortnox.SDK.Connectors;
 using Fortnox.SDK.Interfaces;
-using Fortnox.SDK.Serialization;
 
 namespace Fortnox.SDK;
 
@@ -125,4 +124,6 @@ public class FortnoxClient
     public IVoucherFileConnectionConnector VoucherFileConnectionConnector => Get<VoucherFileConnectionConnector>();
     public IVoucherSeriesConnector VoucherSeriesConnector => Get<VoucherSeriesConnector>();
     public IWayOfDeliveryConnector WayOfDeliveryConnector => Get<WayOfDeliveryConnector>();
+
+    public ITenantConnector TenantConnector => Get<TenantConnector>();
 }

--- a/FortnoxSDK/FortnoxClient.cs
+++ b/FortnoxSDK/FortnoxClient.cs
@@ -3,6 +3,7 @@ using System.Net.Http;
 using Fortnox.SDK.Authorization;
 using Fortnox.SDK.Connectors;
 using Fortnox.SDK.Interfaces;
+using Fortnox.SDK.Serialization;
 
 namespace Fortnox.SDK;
 
@@ -33,6 +34,12 @@ public class FortnoxClient
     /// <value>Defaults to <c>true</c>.</value>
     public bool UseRateLimiter { get; set; } = true;
 
+    /// <summary>
+    /// Some features require warehouse module to be enabled.
+    /// If not set, some properties in the model may be ignored.
+    /// </summary>
+    public bool WarehouseEnabled { get; set; } = false;
+
     public FortnoxClient()
     {
     }
@@ -52,11 +59,12 @@ public class FortnoxClient
 
     private TConnector Get<TConnector>() where TConnector : BaseConnector, new()
     {
-        return new TConnector
+        return new TConnector()
         {
             Authorization = Authorization,
             HttpClient = HttpClient,
             UseRateLimiter = UseRateLimiter,
+            WarehouseEnabled = WarehouseEnabled
         };
     }
 

--- a/FortnoxSDK/FortnoxSDK.csproj
+++ b/FortnoxSDK/FortnoxSDK.csproj
@@ -5,7 +5,7 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <LangVersion>10</LangVersion>
     <PackageId>Fortnox.NET.SDK</PackageId>
-    <Version>4.3.1</Version>
+    <Version>4.3.2-warehouse-rc</Version>
     <Authors>Softwerk AB</Authors>
     <Company>Softwerk AB</Company>
     <Description>SDK package for Fortnox API. This package is developed and maintained by Softwerk AB. For more information please visit the repository on Github.</Description>

--- a/FortnoxSDK/Interfaces/IInvoiceConnector.cs
+++ b/FortnoxSDK/Interfaces/IInvoiceConnector.cs
@@ -22,4 +22,5 @@ public interface IInvoiceConnector : IEntityConnector
     Task<byte[]> PrintReminderAsync(long? id);
     Task<Invoice> ExternalPrintAsync(long? id);
     Task<byte[]> PreviewAsync(long? id);
+    Task<Invoice> WarehouseReady(long? id);
 }

--- a/FortnoxSDK/Interfaces/IOrderConnector.cs
+++ b/FortnoxSDK/Interfaces/IOrderConnector.cs
@@ -18,4 +18,5 @@ public interface IOrderConnector : IEntityConnector
     Task<byte[]> PrintAsync(long? id);
     Task<Order> ExternalPrintAsync(long? id);
     Task<byte[]> PreviewAsync(long? id);
+    Task<Order> WarehouseReady(long? id);
 }

--- a/FortnoxSDK/Interfaces/ITenantConnector.cs
+++ b/FortnoxSDK/Interfaces/ITenantConnector.cs
@@ -1,0 +1,8 @@
+﻿using System.Threading.Tasks;
+using Fortnox.SDK.Entities.Tenants;
+
+namespace Fortnox.SDK.Interfaces;
+public interface ITenantConnector : IEntityConnector
+{
+    Task<Tenant> GetAsync();
+}

--- a/FortnoxSDK/Serialization/WarehouseRequiredAttribute.cs
+++ b/FortnoxSDK/Serialization/WarehouseRequiredAttribute.cs
@@ -1,0 +1,7 @@
+﻿using System;
+
+namespace Fortnox.SDK.Serialization;
+
+public class WarehouseRequiredAttribute : Attribute
+{
+}


### PR DESCRIPTION
- Add warehouse properties e.g. WarehouseReady, DeliveryState, StockPointCode, StockPointId for Order and Invoice model
- Add WarehouseReady action for Order
- Add Tenant endpoint

Note, a property WarehouseEnabled was added to FortnoxClient as a workaround for problematic DeliveryState.
If tenant uses warehouse (can be checked by Tenant endpoint), the property should be set to true before creating Order connector. In other case, DeliveryState won't be deserialized, therefore, can not be updated.