### PR TITLE
Fixed casting issues in Order Entity

### DIFF
--- a/FortnoxSDK/Entities/Orders/Order.cs
+++ b/FortnoxSDK/Entities/Orders/Order.cs
@@ -52,12 +52,12 @@ public class Order
     ///<summary> Contribution in Percent </summary>
     [ReadOnly]
     [JsonProperty]
-    public decimal? ContributionPercent { get; private set; }
+    public string ContributionPercent { get; private set; }
 
     ///<summary> Contribution in amount </summary>
     [ReadOnly]
     [JsonProperty]
-    public decimal? ContributionValue { get; private set; }
+    public string ContributionValue { get; private set; }
 
     ///<summary> If remarks shall be copied from order to invoice </summary>
     [JsonProperty]

--- a/FortnoxSDK/Entities/Orders/OrderRow.cs
+++ b/FortnoxSDK/Entities/Orders/OrderRow.cs
@@ -18,12 +18,12 @@ public class OrderRow
     ///<summary> Contribution Percent </summary>
     [ReadOnly]
     [JsonProperty]
-    public decimal? ContributionPercent { get; private set; }
+    public string ContributionPercent { get; private set; }
 
     ///<summary> Contribution Value </summary>
     [ReadOnly]
     [JsonProperty]
-    public decimal? ContributionValue { get; private set; }
+    public string ContributionValue { get; private set; }
 
     ///<summary> Cost center code </summary>
     [JsonProperty]


### PR DESCRIPTION
Please complete this PR :)

Could not convert string to decimal: API_NORIGHT. Path 'Order.ContributionPercent', line 1, position 360.'
Could not convert string to decimal: API_NORIGHT. Path 'Order.ContributionValue', line 1, position 360.'

Could not convert string to decimal: API_NORIGHT. Path 'Order.OrderRows[0].ContributionPercent', line 1, position 2304.'