### PR TITLE
Null check before Uri.EscapeDataString 

### DIFF
--- a/FortnoxSDK/Requests/BaseRequest.cs
+++ b/FortnoxSDK/Requests/BaseRequest.cs
@@ -20,7 +20,7 @@ internal class BaseRequest
 
     private string BuildUrl()
     {
-        var index = string.Join("/", Indices.Select(Uri.EscapeDataString));
+        var index = string.Join("/", Indices.Where(i => i != null).Select(Uri.EscapeDataString));
 
         var uri = CombineUri(BaseUrl, Endpoint, index);
         var query = BuildQuery(Parameters);


### PR DESCRIPTION
Uri.EscapeDataString doesn't accept null values and since some connectors accept a default value of null on their parameters, that means the 'Indices' property will contain null in some cases. For example GetAsync(string priceListCode, string articleNumber, decimal? fromQuantity = null) in ProceConnector.cs.
Without this null check you will get the following error if you don't specify the fromQuantity parameter:
Value cannot be null. (Parameter 'stringToEscape')