### PR TITLE
Rewrite the GenerateState method

### DIFF
--- a/FortnoxSDK/Auth/StandardAuthWorkflow.cs
+++ b/FortnoxSDK/Auth/StandardAuthWorkflow.cs
@@ -87,7 +87,7 @@ internal class StandardAuthWorkflow : BaseClient, IStandardAuthWorkflow
     public string GenerateState()
     {
         var data = new byte[32];
-        RandomNumberGenerator.GetBytes(data);
+        RandomNumberGenerator.Create().GetBytes(data);
         var state = Convert.ToBase64String(data).Replace('+', '-').Replace('/', '_').TrimEnd('=');
 
         return state;

--- a/FortnoxSDK/Auth/StandardAuthWorkflow.cs
+++ b/FortnoxSDK/Auth/StandardAuthWorkflow.cs
@@ -86,11 +86,7 @@ internal class StandardAuthWorkflow : BaseClient, IStandardAuthWorkflow
 
     public string GenerateState()
     {
-        var data = new byte[32];
-
-        using var rng = new RNGCryptoServiceProvider();
-        rng.GetBytes(data);
-
+        var data = RandomNumberGenerator.GetBytes(32);
         var state = Convert.ToBase64String(data).Replace('+', '-').Replace('/', '_').TrimEnd('=');
 
         return state;

--- a/FortnoxSDK/Auth/StandardAuthWorkflow.cs
+++ b/FortnoxSDK/Auth/StandardAuthWorkflow.cs
@@ -87,7 +87,7 @@ internal class StandardAuthWorkflow : BaseClient, IStandardAuthWorkflow
     public string GenerateState()
     {
         var data = new byte[32];
-        RandomNumberGenerator.GetBytes(32);
+        RandomNumberGenerator.GetBytes(data);
         var state = Convert.ToBase64String(data).Replace('+', '-').Replace('/', '_').TrimEnd('=');
 
         return state;

--- a/FortnoxSDK/Auth/StandardAuthWorkflow.cs
+++ b/FortnoxSDK/Auth/StandardAuthWorkflow.cs
@@ -86,7 +86,8 @@ internal class StandardAuthWorkflow : BaseClient, IStandardAuthWorkflow
 
     public string GenerateState()
     {
-        var data = RandomNumberGenerator.GetBytes(32);
+        var data = new byte[32];
+        RandomNumberGenerator.GetBytes(32);
         var state = Convert.ToBase64String(data).Replace('+', '-').Replace('/', '_').TrimEnd('=');
 
         return state;


### PR DESCRIPTION
Using the static members of the RandomNumberGenerator class is the preferred way to generate random values.

To create a random number generator, call the Create() method. This is preferred over calling the constructor of the derived class RNGCryptoServiceProvider, which is not available on all platforms.

https://learn.microsoft.com/en-us/dotnet/api/system.security.cryptography.randomnumbergenerator