### PR TITLE
Added no-right-value-converter to parse Fortnox API_NORIGHT values

### DIFF
--- a/FortnoxSDK.Tests/Serialization/NoRightValueConverterTests.cs
+++ b/FortnoxSDK.Tests/Serialization/NoRightValueConverterTests.cs
@@ -1,0 +1,56 @@
+﻿using Fortnox.SDK.Entities;
+using Fortnox.SDK.Serialization;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace FortnoxSDK.Tests.Serialization
+{
+    [TestClass]
+    public class NoRightValueConverterTests
+    {
+        [TestMethod]
+        public void Test_Parse_Invoice()
+        {
+            // Arrange
+            var responseJson = @"{
+                ""Comments"": ""TestInvoice"",
+                ""ContractReference"": null,
+                ""ContributionPercent"": 0.5,
+                ""ContributionValue"": ""API_NORIGHT"",
+                ""Country"": null,
+                ""CostCenter"": null,
+                ""Currency"": null,
+                ""CustomerNumber"": ""123467254"",
+                ""DocumentNumber"": null,
+                ""DueDate"": ""2019-02-20T00:00:00"",
+                ""HouseWork"": null,
+                ""InvoiceDate"": ""2019-01-20T00:00:00"",
+                ""InvoicePeriodStart"": null,
+                ""InvoicePeriodEnd"": null,
+                ""InvoiceReference"": null,
+                ""InvoiceRows"": [
+                {
+                    ""ArticleNumber"": ""12427"",
+                    ""DeliveredQuantity"": 10.0,
+                    ""Price"": 100.0,
+                }
+                ],
+                ""InvoiceType"": 4,
+                ""PaymentWay"": 0,
+                ""TotalToPay"": 0.0
+            }";
+
+            // Act
+            var invoice = JsonConvert.DeserializeObject<Invoice>(responseJson, new NoRightValueConverter());
+
+            // Assert both real value and 
+            Assert.AreEqual(null, invoice.ContributionValue);
+            Assert.AreEqual(0.5m, invoice.ContributionPercent);
+        }
+    }
+}

--- a/FortnoxSDK/Serialization/JsonEntitySerializer.cs
+++ b/FortnoxSDK/Serialization/JsonEntitySerializer.cs
@@ -18,6 +18,7 @@ internal class JsonEntitySerializer : ISerializer
         settings = new JsonSerializerSettings();
         settings.DateFormatString = "yyyy-MM-dd";
         settings.Converters.Add(new StringEnumConverter());
+        settings.Converters.Add(new NoRightValueConverter());
         settings.NullValueHandling = NullValueHandling.Ignore;
         settings.ContractResolver = new MyJsonContractResolver(settings, warehouseEnabled);
     }

--- a/FortnoxSDK/Serialization/NoRightValueConverter.cs
+++ b/FortnoxSDK/Serialization/NoRightValueConverter.cs
@@ -1,0 +1,29 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Fortnox.SDK.Serialization
+{
+    /// <summary>
+    /// Fortnox use a magic string value "API_NORIGHT" for when customer is missing a license to features.
+    /// All those properties are nullable and we can simply parse those values as null.
+    /// </summary>
+    public class NoRightValueConverter : JsonConverter
+    {
+        readonly JsonSerializer defaultSerializer = new JsonSerializer();
+
+        public override bool CanConvert(Type objectType)
+            => Nullable.GetUnderlyingType(objectType) != null;
+
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+            => reader.TokenType == JsonToken.String && (string)reader.Value == "API_NORIGHT" ?
+                null : defaultSerializer.Deserialize(reader, objectType);
+
+        public override bool CanWrite 
+            => false;
+
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+            => throw new NotImplementedException();
+    }
+}


### PR DESCRIPTION
This solves issues (ex #263)  when fortnox sends magic string for values that isn't strings.