### PR TITLE
fix: Added missing Voucher reference type 'PAYROLLBOOKKEEP'

### DIFF
--- a/FortnoxSDK/Entities/Vouchers/ReferenceType.cs
+++ b/FortnoxSDK/Entities/Vouchers/ReferenceType.cs
@@ -22,4 +22,6 @@ public enum ReferenceType
     //Not listed in official documentation
     [EnumMember(Value = "RECEIPT")]
     Receipt,
+    [EnumMember(Value = "PAYROLLBOOKKEEP")]
+    PayrollBookkeep,
 }


### PR DESCRIPTION
An undocumented reference type 'PAYROLLBOOKKEEP' is missing from Vouchers reference type.

The error we receieved when using the SDK:
```
Newtonsoft.Json.JsonSerializationException: Error converting value "PAYROLLBOOKKEEP" to type 'System.Nullable`1[Fortnox.SDK.Entities.ReferenceType]'. Path 'Vouchers[210].ReferenceType', line 1, position 57895.
 ---> System.ArgumentException: Requested value 'PAYROLLBOOKKEEP' was not found.
   at Newtonsoft.Json.Utilities.EnumUtils.ParseEnum(Type enumType, NamingStrategy namingStrategy, String value, Boolean disallowNumber)
   at Newtonsoft.Json.Converters.StringEnumConverter.ReadJson(JsonReader reader, Type objectType, Object existingValue, JsonSerializer serializer)
 ```