### PR TITLE
Change constructor to internal

### DIFF
--- a/FortnoxSDK/Exceptions/FortnoxApiException.cs
+++ b/FortnoxSDK/Exceptions/FortnoxApiException.cs
@@ -15,7 +15,7 @@ public class FortnoxApiException : Exception //RequestException
     public HttpStatusCode StatusCode { get; set; }
     public string ResponseContent { get; set; }
 
-    public FortnoxApiException(string message, Exception innerException = null) : base(message, innerException)
+    internal FortnoxApiException(string message, Exception innerException = null) : base(message, innerException)
     {
 
     }

--- a/FortnoxSDK/Exceptions/NoResponseException.cs
+++ b/FortnoxSDK/Exceptions/NoResponseException.cs
@@ -8,7 +8,7 @@ namespace Fortnox.SDK.Exceptions;
 /// </summary>
 public class NoResponseException : Exception
 {
-    public NoResponseException(string message, Exception innerException) : base(message, innerException)
+    internal NoResponseException(string message, Exception innerException) : base(message, innerException)
     {
 
     }


### PR DESCRIPTION
Change the constructor visibility from `public` to `internal` to prevent re-use outside of the library.

Edit: Nevermind. https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1032