### PR TITLE
Add Vat Code to invoice row

### DIFF
--- a/FortnoxSDK/Entities/Invoices/InvoiceRow.cs
+++ b/FortnoxSDK/Entities/Invoices/InvoiceRow.cs
@@ -96,4 +96,9 @@ public class InvoiceRow
     /// <summary> The stock point that the items are to taken from or has been taken from. </summary>
     [JsonProperty]
     public string StockPointCode { get; set; }
+
+    ///<summary> The VATCode has value based on VAT. </summary>
+    [JsonProperty]
+    public string VATCode { get; set; }
+
 }


### PR DESCRIPTION
This fix added for https://github.com/FortnoxAB/csharp-api-sdk/issues/281 this issue we encountered while fetching result where we need VATCode